### PR TITLE
Check the result returned by the function QObject::connect()

### DIFF
--- a/src/FileHistory.cc
+++ b/src/FileHistory.cc
@@ -13,8 +13,8 @@
 #include <QDateTime>
 #include <QFontMetrics>
 
+#include "defmac.h"
 #include "lanes.h"
-
 #include "git.h"
 
 using namespace QGit;
@@ -26,13 +26,13 @@ FileHistory::FileHistory(QObject* p, Git* g) : QAbstractItemModel(p), git(g) {
   revs.reserve(QGit::MAX_DICT_SIZE);
   clear(); // after _headerInfo is set
 
-  connect(git, SIGNAL(newRevsAdded(const FileHistory*, const QVector<ShaString>&)),
-          this, SLOT(on_newRevsAdded(const FileHistory*, const QVector<ShaString>&)));
+  chk_connect_a(git, SIGNAL(newRevsAdded(const FileHistory*, const QVector<ShaString>&)),
+                this, SLOT(on_newRevsAdded(const FileHistory*, const QVector<ShaString>&)))
 
-  connect(git, SIGNAL(loadCompleted(const FileHistory*, const QString&)),
-          this, SLOT(on_loadCompleted(const FileHistory*, const QString&)));
+  chk_connect_a(git, SIGNAL(loadCompleted(const FileHistory*, const QString&)),
+                this, SLOT(on_loadCompleted(const FileHistory*, const QString&)));
 
-  connect(git, SIGNAL(changeFont(const QFont&)), this, SLOT(on_changeFont(const QFont&)));
+  chk_connect_a(git, SIGNAL(changeFont(const QFont&)), this, SLOT(on_changeFont(const QFont&)));
 }
 
 FileHistory::~FileHistory() {

--- a/src/annotate.cpp
+++ b/src/annotate.cpp
@@ -9,6 +9,7 @@
 #include <QApplication>
 #include <QTimer>
 #include "FileHistory.h"
+#include "defmac.h"
 #include "git.h"
 #include "myprocess.h"
 #include "annotate.h"
@@ -26,8 +27,8 @@ Annotate::Annotate(Git* parent, QObject* guiObj) : QObject(parent) {
 	cancelingAnnotate = annotateRunning = annotateActivity = false;
 	valid = canceled = isError = false;
 
-	connect(this, SIGNAL(annotateReady(Annotate*, bool, const QString&)),
-	        git, SIGNAL(annotateReady(Annotate*, bool, const QString&)));
+	chk_connect_a(this, SIGNAL(annotateReady(Annotate*, bool, const QString&)),
+                  git, SIGNAL(annotateReady(Annotate*, bool, const QString&)));
 }
 
 const FileAnnotation* Annotate::lookupAnnotation(SCRef sha) {

--- a/src/commitimpl.cpp
+++ b/src/commitimpl.cpp
@@ -17,6 +17,7 @@
 #include <QKeyEvent>
 #include "exceptionmanager.h"
 #include "common.h"
+#include "defmac.h"
 #include "git.h"
 #include "settingsimpl.h"
 #include "commitimpl.h"
@@ -111,21 +112,21 @@ CommitImpl::CommitImpl(Git* g, bool amend) : git(g) {
 			pushButtonOk->setShortcut(QKeySequence("Alt+A"));
 			pushButtonOk->setToolTip("Amend latest commit");
 		}
-		connect(pushButtonOk, SIGNAL(clicked()),
-			this, SLOT(pushButtonAmend_clicked()));
+		chk_connect_a(pushButtonOk, SIGNAL(clicked()),
+                      this, SLOT(pushButtonAmend_clicked()));
 	} else {
 		if (git->isStGITStack()) {
 			pushButtonOk->setText("&New patch");
 			pushButtonOk->setShortcut(QKeySequence("Alt+N"));
 			pushButtonOk->setToolTip("Create a new patch");
 		}
-		connect(pushButtonOk, SIGNAL(clicked()),
-			this, SLOT(pushButtonCommit_clicked()));
+		chk_connect_a(pushButtonOk, SIGNAL(clicked()),
+                      this, SLOT(pushButtonCommit_clicked()));
 	}
-	connect(treeWidgetFiles, SIGNAL(customContextMenuRequested(const QPoint&)),
-	        this, SLOT(contextMenuPopup(const QPoint&)));
-	connect(textEditMsg, SIGNAL(cursorPositionChanged()),
-	        this, SLOT(textEditMsg_cursorPositionChanged()));
+	chk_connect_a(treeWidgetFiles, SIGNAL(customContextMenuRequested(const QPoint&)),
+                  this, SLOT(contextMenuPopup(const QPoint&)));
+	chk_connect_a(textEditMsg, SIGNAL(cursorPositionChanged()),
+                  this, SLOT(textEditMsg_cursorPositionChanged()));
 
     textEditMsg->installEventFilter(this);
 }
@@ -140,9 +141,9 @@ void CommitImpl::contextMenuPopup(const QPoint& pos)  {
 
 	QMenu* contextMenu = new QMenu(this);
 	QAction* a = contextMenu->addAction("Select All");
-	connect(a, SIGNAL(triggered()), this, SLOT(checkAll()));
+	chk_connect_a(a, SIGNAL(triggered()), this, SLOT(checkAll()));
 	a = contextMenu->addAction("Unselect All");
-	connect(a, SIGNAL(triggered()), this, SLOT(unCheckAll()));
+	chk_connect_a(a, SIGNAL(triggered()), this, SLOT(unCheckAll()));
 	contextMenu->popup(mapToGlobal(pos));
 }
 

--- a/src/dataloader.cpp
+++ b/src/dataloader.cpp
@@ -8,6 +8,7 @@
 */
 #include <QDir>
 #include <QTemporaryFile>
+#include "defmac.h"
 #include "FileHistory.h"
 #include "git.h"
 #include "dataloader.h"
@@ -30,8 +31,8 @@ DataLoader::DataLoader(Git* g, FileHistory* f) : QProcess(g), git(g), fh(f) {
 	loadedBytes = 0;
 	guiUpdateTimer.setSingleShot(true);
 
-	connect(git, SIGNAL(cancelAllProcesses()), this, SLOT(on_cancel()));
-	connect(&guiUpdateTimer, SIGNAL(timeout()), this, SLOT(on_timeout()));
+    chk_connect_a(git, SIGNAL(cancelAllProcesses()), this, SLOT(on_cancel()));
+    chk_connect_a(&guiUpdateTimer, SIGNAL(timeout()), this, SLOT(on_timeout()));
 }
 
 DataLoader::~DataLoader() {
@@ -64,8 +65,8 @@ bool DataLoader::start(SCList args, SCRef wd, SCRef buf) {
 	isProcExited = false;
 	setWorkingDirectory(wd);
 
-	connect(this, SIGNAL(finished(int, QProcess::ExitStatus)),
-	        this, SLOT(on_finished(int, QProcess::ExitStatus)));
+    chk_connect_a(this, SIGNAL(finished(int, QProcess::ExitStatus)),
+                  this, SLOT(on_finished(int, QProcess::ExitStatus)));
 
 	if (!createTemporaryFile() || !QGit::startProcess(this, args, buf)) {
 		deleteLater();

--- a/src/defmac.h
+++ b/src/defmac.h
@@ -1,0 +1,75 @@
+/* clang-format off */
+/****************************************************************************
+  Author:  Karelin Pavel (hkarel), hkarel@yandex.ru
+  This header is defined macros of general purpose.
+****************************************************************************/
+
+#pragma once
+
+#define DISABLE_DEFAULT_CONSTRUCT( ClassName ) \
+    ClassName () = delete;                     \
+    ClassName ( ClassName && ) = delete;       \
+    ClassName ( const ClassName & ) = delete;
+
+#define DISABLE_DEFAULT_COPY( ClassName )      \
+    ClassName ( ClassName && ) = delete;       \
+    ClassName ( const ClassName & ) = delete;  \
+    ClassName & operator = ( ClassName && ) = delete; \
+    ClassName & operator = ( const ClassName & ) = delete;
+
+#define DISABLE_DEFAULT_FUNC( ClassName )      \
+    ClassName () = delete;                     \
+    ClassName ( ClassName && ) = delete;       \
+    ClassName ( const ClassName & ) = delete;  \
+    ClassName & operator = ( ClassName && ) = delete; \
+    ClassName & operator = ( const ClassName & ) = delete;
+
+
+/**
+  The chk_connect macro is used to check the result returned by the function
+  QObject::connect() in debug mode, it looks like on assert() function.
+  However, in the release mode, unlike the assert() function - test expression
+  is not removed.
+  To use the macro in the code need include <assert.h>
+*/
+#ifndef NDEBUG
+#define chk_connect(SOURCE_, SIGNAL_, DEST_, SLOT_, CONNECT_TYPE_) \
+            Q_ASSERT(QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, CONNECT_TYPE_));
+
+// It corresponds to the connection Qt::AutoConnection
+#define chk_connect_a(SOURCE_, SIGNAL_, DEST_, SLOT_) \
+            Q_ASSERT(QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, Qt::AutoConnection));
+
+// It corresponds to the connection Qt::DirectConnection
+#define chk_connect_d(SOURCE_, SIGNAL_, DEST_, SLOT_) \
+            Q_ASSERT(QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, Qt::DirectConnection));
+
+// It corresponds to the connection Qt::QueuedConnection
+#define chk_connect_q(SOURCE_, SIGNAL_, DEST_, SLOT_) \
+            Q_ASSERT(QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, Qt::QueuedConnection));
+
+// It corresponds to the connection Qt::BlockingQueuedConnection
+#define chk_connect_bq(SOURCE_, SIGNAL_, DEST_, SLOT_) \
+            Q_ASSERT(QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, Qt::BlockingQueuedConnection));
+
+#else //NDEBUG
+#define chk_connect(SOURCE_, SIGNAL_, DEST_, SLOT_, CONNECT_TYPE_) \
+            QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, CONNECT_TYPE_);
+
+// It corresponds to the connection Qt::AutoConnection
+#define chk_connect_a(SOURCE_, SIGNAL_, DEST_, SLOT_) \
+            QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, Qt::AutoConnection);
+
+// It corresponds to the connection Qt::DirectConnection
+#define chk_connect_d(SOURCE_, SIGNAL_, DEST_, SLOT_) \
+            QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, Qt::DirectConnection);
+
+// It corresponds to the connection Qt::QueuedConnection
+#define chk_connect_q(SOURCE_, SIGNAL_, DEST_, SLOT_) \
+            QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, Qt::QueuedConnection);
+
+// It corresponds to the connection Qt::BlockingQueuedConnection
+#define chk_connect_bq(SOURCE_, SIGNAL_, DEST_, SLOT_) \
+            QObject::connect(SOURCE_, SIGNAL_, DEST_, SLOT_, Qt::BlockingQueuedConnection);
+
+#endif //NDEBUG

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -201,7 +201,7 @@ bool Domain::setDragging(bool b) {
 void Domain::unlinkDomain(Domain* d) {
 
 	d->linked = false;
-	while (d->disconnect(SIGNAL(updateRequested(StateInfo)), this))
+    while (d->disconnect(SIGNAL(updateRequested(StateInfo)), this))
 		;// a signal is emitted for every connection you make,
 		 // so if you duplicate a connection, two signals will be emitted.
 }
@@ -209,7 +209,7 @@ void Domain::unlinkDomain(Domain* d) {
 void Domain::linkDomain(Domain* d) {
 
 	unlinkDomain(d); // be sure only one connection is active
-	connect(d, SIGNAL(updateRequested(StateInfo)), this, SLOT(on_updateRequested(StateInfo)));
+	chk_connect_a(d, SIGNAL(updateRequested(StateInfo)), this, SLOT(on_updateRequested(StateInfo)));
 	d->linked = true;
 }
 

--- a/src/filecontent.cpp
+++ b/src/filecontent.cpp
@@ -14,6 +14,7 @@
 #include <QClipboard>
 #include <QTemporaryFile>
 #include <QAbstractTextDocumentLayout>
+#include "defmac.h"
 #include "domain.h"
 #include "myprocess.h"
 #include "mainimpl.h"
@@ -82,23 +83,23 @@ void FileContent::setup(Domain* dm, Git* g, QListWidget* lw) {
 
 	clearAll(!optEmitSignal);
 
-	connect(d->m(), SIGNAL(typeWriterFontChanged()),
-	        this, SLOT(typeWriterFontChanged()));
+	chk_connect_a(d->m(), SIGNAL(typeWriterFontChanged()),
+                  this, SLOT(typeWriterFontChanged()));
 
-	connect(git, SIGNAL(annotateReady(Annotate*, bool, const QString&)),
-	        this, SLOT(on_annotateReady(Annotate*, bool, const QString&)));
+	chk_connect_a(git, SIGNAL(annotateReady(Annotate*, bool, const QString&)),
+                  this, SLOT(on_annotateReady(Annotate*, bool, const QString&)));
 
-	connect(listWidgetAnn, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
-	        this, SLOT(on_list_doubleClicked(QListWidgetItem*)));
+	chk_connect_a(listWidgetAnn, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
+                  this, SLOT(on_list_doubleClicked(QListWidgetItem*)));
 
 	QScrollBar* vsb = verticalScrollBar();
-	connect(vsb, SIGNAL(valueChanged(int)),
-	        this, SLOT(on_scrollBar_valueChanged(int)));
+	chk_connect_a(vsb, SIGNAL(valueChanged(int)),
+                  this, SLOT(on_scrollBar_valueChanged(int)));
         vsb->setSingleStep(fontMetrics().lineSpacing());
 
 	vsb = listWidgetAnn->verticalScrollBar();
-	connect(vsb, SIGNAL(valueChanged(int)),
-	        this, SLOT(on_listScrollBar_valueChanged(int)));
+	chk_connect_a(vsb, SIGNAL(valueChanged(int)),
+                  this, SLOT(on_listScrollBar_valueChanged(int)));
         vsb->setSingleStep(fontMetrics().lineSpacing());
 }
 

--- a/src/filelist.cpp
+++ b/src/filelist.cpp
@@ -9,6 +9,7 @@
 #include <QPalette>
 #include <QMimeData>
 #include <QMouseEvent>
+#include "defmac.h"
 #include "git.h"
 #include "domain.h"
 #include "filelist.h"
@@ -23,11 +24,11 @@ void FileList::setup(Domain* dm, Git* g) {
 
 	setFont(QGit::STD_FONT);
 
-	connect(this, SIGNAL(customContextMenuRequested(const QPoint&)),
-	        this, SLOT(on_customContextMenuRequested(const QPoint&)));
+	chk_connect_a(this, SIGNAL(customContextMenuRequested(const QPoint&)),
+                  this, SLOT(on_customContextMenuRequested(const QPoint&)));
 
-	connect(this, SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)),
-	        this, SLOT(on_currentItemChanged(QListWidgetItem*, QListWidgetItem*)));
+	chk_connect_a(this, SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)),
+                  this, SLOT(on_currentItemChanged(QListWidgetItem*, QListWidgetItem*)));
 }
 
 void FileList::addItem(const QString& label, const QColor& clr) {

--- a/src/fileview.cpp
+++ b/src/fileview.cpp
@@ -35,49 +35,49 @@ FileView::FileView(MainImpl* mi, Git* g) : Domain(mi, g, false) {
 
 	fileTab->listWidgetAnn->installEventFilter(this);
 
-	connect(git, SIGNAL(loadCompleted(const FileHistory*, const QString&)),
+	chk_connect_a(git, SIGNAL(loadCompleted(const FileHistory*, const QString&)),
 	        this, SLOT(on_loadCompleted(const FileHistory*, const QString&)));
 
-	connect(m(), SIGNAL(changeFont(const QFont&)),
+	chk_connect_a(m(), SIGNAL(changeFont(const QFont&)),
 	        fileTab->histListView, SLOT(on_changeFont(const QFont&)));
 
-	connect(fileTab->histListView, SIGNAL(contextMenu(const QString&, int)),
+	chk_connect_a(fileTab->histListView, SIGNAL(contextMenu(const QString&, int)),
 	        this, SLOT(on_contextMenu(const QString&, int)));
 
-	connect(fileTab->textEditFile, SIGNAL(annotationAvailable(bool)),
+	chk_connect_a(fileTab->textEditFile, SIGNAL(annotationAvailable(bool)),
 	        this, SLOT(on_annotationAvailable(bool)));
 
-	connect(fileTab->textEditFile, SIGNAL(fileAvailable(bool)),
+	chk_connect_a(fileTab->textEditFile, SIGNAL(fileAvailable(bool)),
 	        this, SLOT(on_fileAvailable(bool)));
 
-	connect(fileTab->textEditFile, SIGNAL(revIdSelected(int)),
+	chk_connect_a(fileTab->textEditFile, SIGNAL(revIdSelected(int)),
 	        this, SLOT(on_revIdSelected(int)));
 
-	connect(fileTab->toolButtonCopy, SIGNAL(clicked()),
+	chk_connect_a(fileTab->toolButtonCopy, SIGNAL(clicked()),
 	        this, SLOT(on_toolButtonCopy_clicked()));
 
-	connect(fileTab->toolButtonShowAnnotate, SIGNAL(toggled(bool)),
+	chk_connect_a(fileTab->toolButtonShowAnnotate, SIGNAL(toggled(bool)),
 	        this, SLOT(on_toolButtonShowAnnotate_toggled(bool)));
 
-	connect(fileTab->toolButtonFindAnnotate, SIGNAL(toggled(bool)),
+	chk_connect_a(fileTab->toolButtonFindAnnotate, SIGNAL(toggled(bool)),
 	        this, SLOT(on_toolButtonFindAnnotate_toggled(bool)));
 
-	connect(fileTab->toolButtonGoNext, SIGNAL(clicked()),
+	chk_connect_a(fileTab->toolButtonGoNext, SIGNAL(clicked()),
 	        this, SLOT(on_toolButtonGoNext_clicked()));
 
-	connect(fileTab->toolButtonGoPrev, SIGNAL(clicked()),
+	chk_connect_a(fileTab->toolButtonGoPrev, SIGNAL(clicked()),
 	        this, SLOT(on_toolButtonGoPrev_clicked()));
 
-	connect(fileTab->toolButtonRangeFilter, SIGNAL(toggled(bool)),
+	chk_connect_a(fileTab->toolButtonRangeFilter, SIGNAL(toggled(bool)),
 	        this, SLOT(on_toolButtonRangeFilter_toggled(bool)));
 
-	connect(fileTab->toolButtonPin, SIGNAL(toggled(bool)),
+	chk_connect_a(fileTab->toolButtonPin, SIGNAL(toggled(bool)),
 	        this, SLOT(on_toolButtonPin_toggled(bool)));
 
-	connect(fileTab->toolButtonHighlightText, SIGNAL(toggled(bool)),
+	chk_connect_a(fileTab->toolButtonHighlightText, SIGNAL(toggled(bool)),
 	        this, SLOT(on_toolButtonHighlightText_toggled(bool)));
 
-	connect(fileTab->spinBoxRevision, SIGNAL(valueChanged(int)),
+	chk_connect_a(fileTab->spinBoxRevision, SIGNAL(valueChanged(int)),
 	        this, SLOT(on_spinBoxRevision_valueChanged(int)));
 }
 

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -20,6 +20,7 @@
 #include "FileHistory.h"
 #include "annotate.h"
 #include "cache.h"
+#include "defmac.h"
 #include "dataloader.h"
 #include "git.h"
 #include "lanes.h"
@@ -535,7 +536,7 @@ MyProcess* Git::runAsScript(SCRef runCmd, QObject* receiver, SCRef buf) {
 
 	MyProcess* p = runAsync(scriptFile, receiver, buf);
 	if (p)
-		connect(p, SIGNAL(eof()), this, SLOT(on_runAsScript_eof()));
+        chk_connect_a(p, SIGNAL(eof()), this, SLOT(on_runAsScript_eof()));
 	return p;
 }
 
@@ -734,7 +735,7 @@ MyProcess* Git::getHighlightedFile(SCRef fileSha, QObject* receiver, QString* re
 	}
 	MyProcess* p = runAsync(runCmd, receiver);
 	if (p)
-		connect(p, SIGNAL(eof()), this, SLOT(on_getHighlightedFile_eof()));
+        chk_connect_a(p, SIGNAL(eof()), this, SLOT(on_getHighlightedFile_eof()));
 	return p;
 }
 
@@ -2092,16 +2093,14 @@ bool Git::startParseProc(SCList initCmd, FileHistory* fh, SCRef buf) {
 
         DataLoader* dl = new DataLoader(this, fh); // auto-deleted when done
 
-        connect(this, SIGNAL(cancelLoading(const FileHistory*)),
-                dl, SLOT(on_cancel(const FileHistory*)));
+        chk_connect_a(this, SIGNAL(cancelLoading(const FileHistory*)),
+                      dl, SLOT(on_cancel(const FileHistory*)));
 
-        connect(dl, SIGNAL(newDataReady(const FileHistory*)),
-                this, SLOT(on_newDataReady(const FileHistory*)));
+        chk_connect_a(dl, SIGNAL(newDataReady(const FileHistory*)),
+                      this, SLOT(on_newDataReady(const FileHistory*)));
 
-        connect(dl, SIGNAL(loaded(FileHistory*, ulong, int,
-                bool, const QString&, const QString&)), this,
-                SLOT(on_loaded(FileHistory*, ulong, int,
-                bool, const QString&, const QString&)));
+        chk_connect_a(dl, SIGNAL(loaded(FileHistory*, ulong, int, bool, QString, QString)),
+                      this, SLOT(on_loaded(FileHistory*, ulong, int, bool, QString, QString)));
 
         return dl->start(initCmd, workDir, buf);
 }

--- a/src/inputdialog.cpp
+++ b/src/inputdialog.cpp
@@ -1,5 +1,6 @@
 #include "inputdialog.h"
 #include "common.h"
+#include "defmac.h"
 #include <QLineEdit>
 #include <QTextEdit>
 #include <QComboBox>
@@ -114,7 +115,7 @@ InputDialog::InputDialog(const QString &cmd, const VariableMap &variables,
 			if (opts.contains("ref")) {
 				w->setValidator(new RefNameValidator(opts.contains("empty")));
 				validators.insert(name, w->validator());
-				connect(w, SIGNAL(editTextChanged(QString)), this, SLOT(validate()));
+				chk_connect_a(w, SIGNAL(editTextChanged(QString)), this, SLOT(validate()));
 			}
 			item->init(w, "currentText");
 		} else if (type == "listbox") {
@@ -130,7 +131,7 @@ InputDialog::InputDialog(const QString &cmd, const VariableMap &variables,
 			if (opts.contains("ref")) {
 				w->setValidator(new RefNameValidator(opts.contains("empty")));
 				validators.insert(name, w->validator());
-				connect(w, SIGNAL(textEdited(QString)), this, SLOT(validate()));
+				chk_connect_a(w, SIGNAL(textEdited(QString)), this, SLOT(validate()));
 			}
 			item->init(w, "text");
 		} else if (type == "textedit") {
@@ -154,8 +155,8 @@ InputDialog::InputDialog(const QString &cmd, const VariableMap &variables,
 	layout->addWidget(buttons, row, 0, 1, 2);
 	okButton = buttons->button(QDialogButtonBox::Ok);
 
-	connect(okButton, SIGNAL(pressed()), this, SLOT(accept()));
-	connect(buttons->button(QDialogButtonBox::Cancel), SIGNAL(pressed()), this, SLOT(reject()));
+	chk_connect_a(okButton, SIGNAL(pressed()), this, SLOT(accept()));
+	chk_connect_a(buttons->button(QDialogButtonBox::Cancel), SIGNAL(pressed()), this, SLOT(reject()));
 	validate();
 }
 

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -14,6 +14,7 @@
 #include <QPixmap>
 #include <QShortcut>
 #include "FileHistory.h"
+#include "defmac.h"
 #include "domain.h"
 #include "git.h"
 #include "listview.h"
@@ -47,12 +48,12 @@ void ListView::setup(Domain* dm, Git* g) {
 	new QShortcut(Qt::Key_Up,   this, SLOT(on_keyUp()));
 	new QShortcut(Qt::Key_Down, this, SLOT(on_keyDown()));
 
-	connect(lvd, SIGNAL(updateView()), viewport(), SLOT(update()));
+	chk_connect_a(lvd, SIGNAL(updateView()), viewport(), SLOT(update()));
 
-	connect(this, SIGNAL(diffTargetChanged(int)), lvd, SLOT(diffTargetChanged(int)));
+	chk_connect_a(this, SIGNAL(diffTargetChanged(int)), lvd, SLOT(diffTargetChanged(int)));
 
-	connect(this, SIGNAL(customContextMenuRequested(const QPoint&)),
-	        this, SLOT(on_customContextMenuRequested(const QPoint&)));
+	chk_connect_a(this, SIGNAL(customContextMenuRequested(const QPoint&)),
+                  this, SLOT(on_customContextMenuRequested(const QPoint&)));
 }
 
 ListView::~ListView() {

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -62,8 +62,8 @@ MainImpl::MainImpl(SCRef cd, QWidget* p) : QMainWindow(p) {
 	toolBar->addWidget(lineEditSHA);
 	QAction* act = toolBar->insertWidget(ActSearchAndFilter, lineEditFilter);
 	toolBar->insertWidget(act, cmbSearch);
-	connect(lineEditSHA, SIGNAL(returnPressed()), this, SLOT(lineEditSHA_returnPressed()));
-	connect(lineEditFilter, SIGNAL(returnPressed()), this, SLOT(lineEditFilter_returnPressed()));
+	chk_connect_a(lineEditSHA, SIGNAL(returnPressed()), this, SLOT(lineEditSHA_returnPressed()));
+	chk_connect_a(lineEditFilter, SIGNAL(returnPressed()), this, SLOT(lineEditFilter_returnPressed()));
 
 	// create light and dark colors for alternate background
 	ODD_LINE_COL = palette().color(QPalette::Base);
@@ -112,8 +112,8 @@ MainImpl::MainImpl(SCRef cd, QWidget* p) : QMainWindow(p) {
 	ct->setToolTip("Close tab");
 	ct->setEnabled(false);
 	tabWdg->setCornerWidget(ct);
-	connect(ct, SIGNAL(clicked()), this, SLOT(pushButtonCloseTab_clicked()));
-	connect(this, SIGNAL(closeTabButtonEnabled(bool)), ct, SLOT(setEnabled(bool)));
+	chk_connect_a(ct, SIGNAL(clicked()), this, SLOT(pushButtonCloseTab_clicked()));
+	chk_connect_a(this, SIGNAL(closeTabButtonEnabled(bool)), ct, SLOT(setEnabled(bool)));
 
 	// set-up file names loading progress bar
 	pbFileNamesLoading = new QProgressBar(statusBar());
@@ -127,11 +127,11 @@ MainImpl::MainImpl(SCRef cd, QWidget* p) : QMainWindow(p) {
 	treeView->hide();
 
 	// set-up menu for recent visited repositories
-	connect(File, SIGNAL(triggered(QAction*)), this, SLOT(openRecent_triggered(QAction*)));
+	chk_connect_a(File, SIGNAL(triggered(QAction*)), this, SLOT(openRecent_triggered(QAction*)));
 	doUpdateRecentRepoMenu("");
 
 	// set-up menu for custom actions
-	connect(Actions, SIGNAL(triggered(QAction*)), this, SLOT(customAction_triggered(QAction*)));
+	chk_connect_a(Actions, SIGNAL(triggered(QAction*)), this, SLOT(customAction_triggered(QAction*)));
 	doUpdateCustomActionMenu(settings.value(ACT_LIST_KEY).toStringList());
 
 	// manual adjust lineEditSHA width
@@ -142,25 +142,25 @@ MainImpl::MainImpl(SCRef cd, QWidget* p) : QMainWindow(p) {
 	// disable all actions
 	updateGlobalActions(false);
 
-	connect(git, SIGNAL(fileNamesLoad(int, int)), this, SLOT(fileNamesLoad(int, int)));
+	chk_connect_a(git, SIGNAL(fileNamesLoad(int, int)), this, SLOT(fileNamesLoad(int, int)));
 
-	connect(git, SIGNAL(newRevsAdded(const FileHistory*, const QVector<ShaString>&)),
+	chk_connect_a(git, SIGNAL(newRevsAdded(const FileHistory*, const QVector<ShaString>&)),
 	        this, SLOT(newRevsAdded(const FileHistory*, const QVector<ShaString>&)));
 
-	connect(this, SIGNAL(typeWriterFontChanged()), this, SIGNAL(updateRevDesc()));
+	chk_connect_a(this, SIGNAL(typeWriterFontChanged()), this, SIGNAL(updateRevDesc()));
 
-	connect(this, SIGNAL(changeFont(const QFont&)), git, SIGNAL(changeFont(const QFont&)));
+	chk_connect_a(this, SIGNAL(changeFont(const QFont&)), git, SIGNAL(changeFont(const QFont&)));
 
 	// connect cross-domain update signals
-	connect(rv->tab()->listViewLog, SIGNAL(doubleClicked(const QModelIndex&)),
+	chk_connect_a(rv->tab()->listViewLog, SIGNAL(doubleClicked(const QModelIndex&)),
 	        this, SLOT(listViewLog_doubleClicked(const QModelIndex&)));
-	connect(rv->tab()->listViewLog, SIGNAL(showStatusMessage(const QString&)),
+	chk_connect_a(rv->tab()->listViewLog, SIGNAL(showStatusMessage(const QString&)),
 	        statusBar(), SLOT(showMessage(const QString&)));
 
-	connect(rv->tab()->fileList, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
+	chk_connect_a(rv->tab()->fileList, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
 	        this, SLOT(fileList_itemDoubleClicked(QListWidgetItem*)));
 
-	connect(treeView, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)),
+	chk_connect_a(treeView, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)),
 	        this, SLOT(treeView_doubleClicked(QTreeWidgetItem*, int)));
 
 	// use most recent repo as startup dir if it exists and user opted to do so
@@ -624,10 +624,10 @@ void MainImpl::openFileTab(FileView* fv) {
 		fv = new FileView(this, git);
 		tabWdg->addTab(fv->tabPage(), "File");
 
-		connect(fv->tab()->histListView, SIGNAL(doubleClicked(const QModelIndex&)),
+		chk_connect_a(fv->tab()->histListView, SIGNAL(doubleClicked(const QModelIndex&)),
 		        this, SLOT(histListView_doubleClicked(const QModelIndex&)));
 
-		connect(this, SIGNAL(closeAllTabs()), fv, SLOT(on_closeAllTabs()));
+		chk_connect_a(this, SIGNAL(closeAllTabs()), fv, SLOT(on_closeAllTabs()));
 
 		ActViewFileNewTab->setEnabled(ActViewFile->isEnabled());
 	}
@@ -1220,7 +1220,7 @@ void MainImpl::doContexPopup(SCRef sha) {
 	QMenu contextTagMenu("More tags...", this);
 	QMenu contextRmtMenu("Remote branches...", this);
 
-	connect(&contextMenu, SIGNAL(triggered(QAction*)), this, SLOT(goRef_triggered(QAction*)));
+	chk_connect_a(&contextMenu, SIGNAL(triggered(QAction*)), this, SLOT(goRef_triggered(QAction*)));
 
 	Domain* t;
 	int tt = currentTabType(&t);
@@ -1582,10 +1582,10 @@ void MainImpl::ActCheckWorkDir_toggled(bool b) {
 void MainImpl::ActSettings_activated() {
 
 	SettingsImpl setView(this, git);
-	connect(&setView, SIGNAL(typeWriterFontChanged()),
+	chk_connect_a(&setView, SIGNAL(typeWriterFontChanged()),
 	        this, SIGNAL(typeWriterFontChanged()));
 
-	connect(&setView, SIGNAL(flagChanged(uint)),
+	chk_connect_a(&setView, SIGNAL(flagChanged(uint)),
 	        this, SIGNAL(flagChanged(uint)));
 
 	setView.exec();
@@ -1599,8 +1599,8 @@ void MainImpl::ActCustomActionSetup_activated() {
 
 	CustomActionImpl* ca = new CustomActionImpl(); // has Qt::WA_DeleteOnClose
 
-	connect(this, SIGNAL(closeAllWindows()), ca, SLOT(close()));
-	connect(ca, SIGNAL(listChanged(const QStringList&)),
+	chk_connect_a(this, SIGNAL(closeAllWindows()), ca, SLOT(close()));
+	chk_connect_a(ca, SIGNAL(listChanged(const QStringList&)),
 	        this, SLOT(customActionListChanged(const QStringList&)));
 
 	ca->show();
@@ -1665,11 +1665,11 @@ void MainImpl::customAction_triggered(QAction* act) {
 
 	ConsoleImpl* c = new ConsoleImpl(actionName, git); // has Qt::WA_DeleteOnClose attribute
 
-	connect(this, SIGNAL(typeWriterFontChanged()),
+	chk_connect_a(this, SIGNAL(typeWriterFontChanged()),
 	        c, SLOT(typeWriterFontChanged()));
 
-	connect(this, SIGNAL(closeAllWindows()), c, SLOT(close()));
-	connect(c, SIGNAL(customAction_exited(const QString&)),
+	chk_connect_a(this, SIGNAL(closeAllWindows()), c, SLOT(close()));
+	chk_connect_a(c, SIGNAL(customAction_exited(const QString&)),
 	        this, SLOT(customAction_exited(const QString&)));
 
 	if (c->start(cmd))
@@ -1686,16 +1686,16 @@ void MainImpl::customAction_exited(const QString& name) {
 void MainImpl::ActCommit_activated() {
 
 	CommitImpl* c = new CommitImpl(git, false); // has Qt::WA_DeleteOnClose attribute
-	connect(this, SIGNAL(closeAllWindows()), c, SLOT(close()));
-	connect(c, SIGNAL(changesCommitted(bool)), this, SLOT(changesCommitted(bool)));
+	chk_connect_a(this, SIGNAL(closeAllWindows()), c, SLOT(close()));
+	chk_connect_a(c, SIGNAL(changesCommitted(bool)), this, SLOT(changesCommitted(bool)));
 	c->show();
 }
 
 void MainImpl::ActAmend_activated() {
 
 	CommitImpl* c = new CommitImpl(git, true); // has Qt::WA_DeleteOnClose attribute
-	connect(this, SIGNAL(closeAllWindows()), c, SLOT(close()));
-	connect(c, SIGNAL(changesCommitted(bool)), this, SLOT(changesCommitted(bool)));
+	chk_connect_a(this, SIGNAL(closeAllWindows()), c, SLOT(close()));
+	chk_connect_a(c, SIGNAL(changesCommitted(bool)), this, SLOT(changesCommitted(bool)));
 	c->show();
 }
 
@@ -2043,7 +2043,7 @@ void MainImpl::ActHelp_activated() {
 	Ui::HelpBase ui;
 	ui.setupUi(dlg);
 	ui.textEditHelp->setHtml(QString::fromLatin1(helpInfo)); // defined in help.h
-	connect(this, SIGNAL(closeAllWindows()), dlg, SLOT(close()));
+	chk_connect_a(this, SIGNAL(closeAllWindows()), dlg, SLOT(close()));
 	dlg->show();
 	dlg->raise();
 }

--- a/src/mainimpl.h
+++ b/src/mainimpl.h
@@ -12,6 +12,7 @@
 #include <QDir>
 #include "exceptionmanager.h"
 #include "common.h"
+#include "defmac.h"
 #include "ui_mainview.h"
 
 class QAction;
@@ -191,8 +192,8 @@ public:
 	ExternalDiffProc(const QStringList& f, QObject* p)
 		: QProcess(p), filenames(f) {
 
-		connect(this, SIGNAL(finished(int, QProcess::ExitStatus)),
-		        this, SLOT(on_finished(int, QProcess::ExitStatus)));
+		chk_connect_a(this, SIGNAL(finished(int, QProcess::ExitStatus)),
+                      this, SLOT(on_finished(int, QProcess::ExitStatus)));
 	}
 	~ExternalDiffProc() {
 
@@ -221,8 +222,8 @@ public:
 	ExternalEditorProc(QObject* p)
 	    : QProcess(p) {
 
-		connect(this, SIGNAL(finished(int, QProcess::ExitStatus)),
-		        this, SLOT(on_finished(int, QProcess::ExitStatus)));
+		chk_connect_a(this, SIGNAL(finished(int, QProcess::ExitStatus)),
+                      this, SLOT(on_finished(int, QProcess::ExitStatus)));
 	}
 	~ExternalEditorProc() {
 		terminate();

--- a/src/myprocess.cpp
+++ b/src/myprocess.cpp
@@ -10,6 +10,7 @@
 #include <QTime>
 #include "exceptionmanager.h"
 #include "common.h"
+#include "defmac.h"
 #include "domain.h"
 #include "myprocess.h"
 
@@ -67,28 +68,28 @@ bool MyProcess::runSync(SCRef rc, QByteArray* ro, QObject* rcv, SCRef buf) {
 
 void MyProcess::setupSignals() {
 
-	connect(git, SIGNAL(cancelAllProcesses()),
-	        this, SLOT(on_cancel()));
+	chk_connect_a(git, SIGNAL(cancelAllProcesses()),
+                 this, SLOT(on_cancel()));
 
-	connect(this, SIGNAL(readyReadStandardOutput()),
-	        this, SLOT(on_readyReadStandardOutput()));
+    chk_connect_a(this, SIGNAL(readyReadStandardOutput()),
+                  this, SLOT(on_readyReadStandardOutput()));
 
-	connect(this, SIGNAL(finished(int, QProcess::ExitStatus)),
-	        this, SLOT(on_finished(int, QProcess::ExitStatus)));
+	chk_connect_a(this, SIGNAL(finished(int, QProcess::ExitStatus)),
+                  this, SLOT(on_finished(int, QProcess::ExitStatus)));
 
 	if (receiver) {
 
-		connect(this, SIGNAL(readyReadStandardError ()),
-		        this, SLOT(on_readyReadStandardError()));
+		chk_connect_a(this, SIGNAL(readyReadStandardError ()),
+                      this, SLOT(on_readyReadStandardError()));
 
-		connect(this, SIGNAL(procDataReady(const QByteArray&)),
-		        receiver, SLOT(procReadyRead(const QByteArray&)));
+		chk_connect_a(this, SIGNAL(procDataReady(const QByteArray&)),
+                      receiver, SLOT(procReadyRead(const QByteArray&)));
 
-		connect(this, SIGNAL(eof()), receiver, SLOT(procFinished()));
+		chk_connect_a(this, SIGNAL(eof()), receiver, SLOT(procFinished()));
 	}
 	Domain* d = git->curContext();
 	if (d)
-		connect(d, SIGNAL(cancelDomainProcesses()), this, SLOT(on_cancel()));
+		chk_connect_a(d, SIGNAL(cancelDomainProcesses()), this, SLOT(on_cancel()));
 }
 
 void MyProcess::sendErrorMsg(bool notStarted, SCRef err) {

--- a/src/patchview.cpp
+++ b/src/patchview.cpp
@@ -24,25 +24,25 @@ PatchView::PatchView(MainImpl* mi, Git* g) : Domain(mi, g, false) {
 	bg->addButton(patchTab->radioButtonParent, DIFF_TO_PARENT);
 	bg->addButton(patchTab->radioButtonHead, DIFF_TO_HEAD);
 	bg->addButton(patchTab->radioButtonSha, DIFF_TO_SHA);
-	connect(bg, SIGNAL(buttonClicked(int)), this, SLOT(button_clicked(int)));
+	chk_connect_a(bg, SIGNAL(buttonClicked(int)), this, SLOT(button_clicked(int)));
 
 	patchTab->textBrowserDesc->setup(this);
 	patchTab->textEditDiff->setup(this, git);
 	patchTab->fileList->setup(this, git);
 
-	connect(m(), SIGNAL(typeWriterFontChanged()),
+	chk_connect_a(m(), SIGNAL(typeWriterFontChanged()),
 	        patchTab->textEditDiff, SLOT(typeWriterFontChanged()));
 
-	connect(m(), SIGNAL(changeFont(const QFont&)),
+	chk_connect_a(m(), SIGNAL(changeFont(const QFont&)),
 	       patchTab->fileList, SLOT(on_changeFont(const QFont&)));
 
-	connect(patchTab->lineEditDiff, SIGNAL(returnPressed()),
+	chk_connect_a(patchTab->lineEditDiff, SIGNAL(returnPressed()),
 	        this, SLOT(lineEditDiff_returnPressed()));
 
-	connect(patchTab->fileList, SIGNAL(contextMenu(const QString&, int)),
+	chk_connect_a(patchTab->fileList, SIGNAL(contextMenu(const QString&, int)),
 	        this, SLOT(on_contextMenu(const QString&, int)));
 
-	connect(patchTab->buttonFilterPatch, SIGNAL(clicked()),
+	chk_connect_a(patchTab->buttonFilterPatch, SIGNAL(clicked()),
 	        this, SLOT(buttonFilterPatch_clicked()));
 }
 

--- a/src/qgit.cpp
+++ b/src/qgit.cpp
@@ -6,6 +6,7 @@
 */
 #include <QSettings>
 #include "common.h"
+#include "defmac.h"
 #include "mainimpl.h"
 
 #if defined(_MSC_VER) && defined(NDEBUG)
@@ -32,7 +33,7 @@ int main(int argc, char* argv[]) {
 
 	MainImpl* mainWin = new MainImpl;
 	mainWin->show();
-	QObject::connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
+    chk_connect_a(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
 	bool ret = app.exec();
 
 	freeMimePix();

--- a/src/revdesc.cpp
+++ b/src/revdesc.cpp
@@ -8,16 +8,17 @@
 #include <QContextMenuEvent>
 #include <QRegExp>
 #include <QClipboard>
+#include "defmac.h"
 #include "domain.h"
 #include "revdesc.h"
 
 RevDesc::RevDesc(QWidget* p) : QTextBrowser(p), d(NULL) {
 
-	connect(this, SIGNAL(anchorClicked(const QUrl&)),
-	        this, SLOT(on_anchorClicked(const QUrl&)));
+	chk_connect_a(this, SIGNAL(anchorClicked(const QUrl&)),
+                  this, SLOT(on_anchorClicked(const QUrl&)));
 
-	connect(this, SIGNAL(highlighted(const QUrl&)),
-	        this, SLOT(on_highlighted(const QUrl&)));
+	chk_connect_a(this, SIGNAL(highlighted(const QUrl&)),
+                  this, SLOT(on_highlighted(const QUrl&)));
 }
 
 void RevDesc::on_anchorClicked(const QUrl& link) {
@@ -47,7 +48,7 @@ void RevDesc::contextMenuEvent(QContextMenuEvent* e) {
 	QMenu* menu = createStandardContextMenu();
 	if (!highlightedLink.isEmpty()) {
 		QAction* act = menu->addAction("Copy link SHA1");
-		connect(act, SIGNAL(triggered()), this, SLOT(on_linkCopy()));
+		chk_connect_a(act, SIGNAL(triggered()), this, SLOT(on_linkCopy()));
 	}
 	menu->exec(e->globalPos());
 	delete menu;

--- a/src/revsview.cpp
+++ b/src/revsview.cpp
@@ -40,46 +40,46 @@ RevsView::RevsView(MainImpl* mi, Git* g, bool isMain) : Domain(mi, g, isMain) {
 	v << tab()->horizontalSplitter << tab()->verticalSplitter;
 	QGit::restoreGeometrySetting(QGit::REV_GEOM_KEY, NULL, &v);
 
-	connect(m(), SIGNAL(typeWriterFontChanged()),
+	chk_connect_a(m(), SIGNAL(typeWriterFontChanged()),
 	        tab()->textEditDiff, SLOT(typeWriterFontChanged()));
 
-	connect(m(), SIGNAL(flagChanged(uint)),
+	chk_connect_a(m(), SIGNAL(flagChanged(uint)),
 	        sb, SLOT(flagChanged(uint)));
 
-	connect(git, SIGNAL(newRevsAdded(const FileHistory*, const QVector<ShaString>&)),
+	chk_connect_a(git, SIGNAL(newRevsAdded(const FileHistory*, const QVector<ShaString>&)),
 	        this, SLOT(on_newRevsAdded(const FileHistory*, const QVector<ShaString>&)));
 
-	connect(git, SIGNAL(loadCompleted(const FileHistory*, const QString&)),
+	chk_connect_a(git, SIGNAL(loadCompleted(const FileHistory*, const QString&)),
 	        this, SLOT(on_loadCompleted(const FileHistory*, const QString&)));
 
-	connect(m(), SIGNAL(changeFont(const QFont&)),
+	chk_connect_a(m(), SIGNAL(changeFont(const QFont&)),
 	        tab()->listViewLog, SLOT(on_changeFont(const QFont&)));
 
-	connect(m(), SIGNAL(updateRevDesc()), this, SLOT(on_updateRevDesc()));
+	chk_connect_a(m(), SIGNAL(updateRevDesc()), this, SLOT(on_updateRevDesc()));
 
-	connect(tab()->listViewLog, SIGNAL(lanesContextMenuRequested(const QStringList&,
+	chk_connect_a(tab()->listViewLog, SIGNAL(lanesContextMenuRequested(const QStringList&,
 	        const QStringList&)), this, SLOT(on_lanesContextMenuRequested
 	       (const QStringList&, const QStringList&)));
 
-	connect(tab()->listViewLog, SIGNAL(revisionsDragged(const QStringList&)),
+	chk_connect_a(tab()->listViewLog, SIGNAL(revisionsDragged(const QStringList&)),
 	        m(), SLOT(revisionsDragged(const QStringList&)));
 
-	connect(tab()->listViewLog, SIGNAL(revisionsDropped(const QStringList&)),
+	chk_connect_a(tab()->listViewLog, SIGNAL(revisionsDropped(const QStringList&)),
 	        m(), SLOT(revisionsDropped(const QStringList&)));
 
-	connect(tab()->listViewLog, SIGNAL(contextMenu(const QString&, int)),
+	chk_connect_a(tab()->listViewLog, SIGNAL(contextMenu(const QString&, int)),
 	        this, SLOT(on_contextMenu(const QString&, int)));
 
-	connect(m()->treeView, SIGNAL(contextMenu(const QString&, int)),
+	chk_connect_a(m()->treeView, SIGNAL(contextMenu(const QString&, int)),
 	        this, SLOT(on_contextMenu(const QString&, int)));
 
-	connect(tab()->fileList, SIGNAL(contextMenu(const QString&, int)),
+	chk_connect_a(tab()->fileList, SIGNAL(contextMenu(const QString&, int)),
 	        this, SLOT(on_contextMenu(const QString&, int)));
 
-	connect(m(), SIGNAL(changeFont(const QFont&)),
+	chk_connect_a(m(), SIGNAL(changeFont(const QFont&)),
 	       tab()->fileList, SLOT(on_changeFont(const QFont&)));
 
-	connect(m(), SIGNAL(highlightPatch(const QString&, bool)),
+	chk_connect_a(m(), SIGNAL(highlightPatch(const QString&, bool)),
 	        tab()->textEditDiff, SLOT(on_highlightPatch(const QString&, bool)));
 }
 
@@ -186,14 +186,14 @@ void RevsView::viewPatch(bool newTab) {
 		linkedPatchView = pv;
 		linkDomain(linkedPatchView);
 
-		connect(m(), SIGNAL(highlightPatch(const QString&, bool)),
+		chk_connect_a(m(), SIGNAL(highlightPatch(const QString&, bool)),
 			pv->tab()->textEditDiff, SLOT(on_highlightPatch(const QString&, bool)));
 
-		connect(pv->tab()->fileList, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
+		chk_connect_a(pv->tab()->fileList, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
 			m(), SLOT(fileList_itemDoubleClicked(QListWidgetItem*)));
 	}
-	connect(m(), SIGNAL(updateRevDesc()), pv, SLOT(on_updateRevDesc()));
-	connect(m(), SIGNAL(closeAllTabs()), pv, SLOT(on_closeAllTabs()));
+	chk_connect_a(m(), SIGNAL(updateRevDesc()), pv, SLOT(on_updateRevDesc()));
+	chk_connect_a(m(), SIGNAL(closeAllTabs()), pv, SLOT(on_closeAllTabs()));
 	pv->st = st;
 	UPDATE_DM_MASTER(pv, false);
 }

--- a/src/smartbrowse.cpp
+++ b/src/smartbrowse.cpp
@@ -9,6 +9,7 @@
 #include <QPainter>
 #include <QScrollBar>
 #include <QWheelEvent>
+#include "defmac.h"
 #include "revsview.h"
 #include "smartbrowse.h"
 
@@ -99,23 +100,23 @@ SmartBrowse::SmartBrowse(RevsView* par) : QObject(par) {
 	log->horizontalScrollBar()->installEventFilter(this);
 	diff->horizontalScrollBar()->installEventFilter(this);
 
-	connect(vsbLog, SIGNAL(valueChanged(int)),
-	        this, SLOT(updateVisibility()));
+	chk_connect_a(vsbLog, SIGNAL(valueChanged(int)),
+                  this, SLOT(updateVisibility()));
 
-	connect(vsbDiff, SIGNAL(valueChanged(int)),
-	        this, SLOT(updateVisibility()));
+	chk_connect_a(vsbDiff, SIGNAL(valueChanged(int)),
+                  this, SLOT(updateVisibility()));
 
-	connect(logTopLbl, SIGNAL(linkActivated(const QString&)),
-	        this, SLOT(linkActivated(const QString&)));
+	chk_connect_a(logTopLbl, SIGNAL(linkActivated(const QString&)),
+                  this, SLOT(linkActivated(const QString&)));
 
-	connect(logBottomLbl, SIGNAL(linkActivated(const QString&)),
-	        this, SLOT(linkActivated(const QString&)));
+	chk_connect_a(logBottomLbl, SIGNAL(linkActivated(const QString&)),
+                  this, SLOT(linkActivated(const QString&)));
 
-	connect(diffTopLbl, SIGNAL(linkActivated(const QString&)),
-	        this, SLOT(linkActivated(const QString&)));
+	chk_connect_a(diffTopLbl, SIGNAL(linkActivated(const QString&)),
+                  this, SLOT(linkActivated(const QString&)));
 
-	connect(diffBottomLbl, SIGNAL(linkActivated(const QString&)),
-	        this, SLOT(linkActivated(const QString&)));
+	chk_connect_a(diffBottomLbl, SIGNAL(linkActivated(const QString&)),
+                  this, SLOT(linkActivated(const QString&)));
 }
 
 void SmartBrowse::setVisible(bool b) {

--- a/src/src.pro
+++ b/src/src.pro
@@ -53,6 +53,11 @@ macx {
     RC_FILE = resources/qgit.icns
 }
 
+CONFIG(release, debug|release) {
+    #This is a release build
+    DEFINES += NDEBUG
+}
+
 HAVE_GCC {
 	QMAKE_CXXFLAGS_RELEASE += -s -O2 -Wno-non-virtual-dtor -Wno-long-long -pedantic -Wconversion
 	QMAKE_CXXFLAGS_DEBUG += -g3 -ggdb -O0 -Wno-non-virtual-dtor -Wno-long-long -pedantic -Wconversion

--- a/src/src.qbs
+++ b/src/src.qbs
@@ -124,6 +124,7 @@ Product {
         "dataloader.h",
         "domain.cpp",
         "domain.h",
+        "defmac.h",
         "exceptionmanager.cpp",
         "exceptionmanager.h",
         "filecontent.cpp",

--- a/src/src.qbs
+++ b/src/src.qbs
@@ -28,6 +28,8 @@ Product {
     cpp.cxxFlags: {
         var cxx = [
             "-std=c++11",
+            "-Wall",
+            "-Wextra",
             "-Wno-non-virtual-dtor",
             "-Wno-long-long",
             "-pedantic",

--- a/src/treeview.cpp
+++ b/src/treeview.cpp
@@ -9,6 +9,7 @@
 #include <QApplication>
 #include <QTreeWidgetItemIterator>
 #include "git.h"
+#include "defmac.h"
 #include "domain.h"
 #include "mainimpl.h"
 #include "treeview.h"
@@ -50,17 +51,17 @@ void TreeView::setup(Domain* dm, Git* g) {
 	folderOpen   = QGit::mimePix(".#folder_open");
 	fileDefault  = QGit::mimePix(".#default");
 
-	connect(this, SIGNAL(itemExpanded(QTreeWidgetItem*)),
-	        this, SLOT(on_itemExpanded(QTreeWidgetItem*)));
+	chk_connect_a(this, SIGNAL(itemExpanded(QTreeWidgetItem*)),
+                  this, SLOT(on_itemExpanded(QTreeWidgetItem*)));
 
-	connect(this, SIGNAL(itemCollapsed(QTreeWidgetItem*)),
-	        this, SLOT(on_itemCollapsed(QTreeWidgetItem*)));
+	chk_connect_a(this, SIGNAL(itemCollapsed(QTreeWidgetItem*)),
+                  this, SLOT(on_itemCollapsed(QTreeWidgetItem*)));
 
-	connect(this, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)),
-	        this, SLOT(on_currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)));
+	chk_connect_a(this, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)),
+                  this, SLOT(on_currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)));
 
-	connect(this, SIGNAL(customContextMenuRequested(const QPoint&)),
-	        this, SLOT(on_customContextMenuRequested(const QPoint&)));
+	chk_connect_a(this, SIGNAL(customContextMenuRequested(const QPoint&)),
+                  this, SLOT(on_customContextMenuRequested(const QPoint&)));
 }
 
 void TreeView::on_currentItemChanged(QTreeWidgetItem* item, QTreeWidgetItem*) {


### PR DESCRIPTION
The chk_connect macro is used to check the result returned by the function
QObject::connect() in debug mode, it looks like on assert() function.
However, in the release mode, unlike the assert() function - test expression
is not removed. 
To use the macro in the code need include "assert.h"
