### PR TITLE
Fix error message spelling

### DIFF
--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -1465,7 +1465,7 @@ void MainImpl::openRecent_triggered(QAction* act) {
 			setRepository(workDir);
 		else
 			statusBar()->showMessage("Directory '" + workDir +
-			                         "' does not seem to exsist anymore");
+			                         "' does not seem to exist anymore");
 	}
 }
 


### PR DESCRIPTION
When opening a nonexistent directory from the recently used repositories list,
the error message contained a spelling mistake.
Bug report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=851193