### PR TITLE
Fix broken keybindings (i.e. n, k) and adjust Readme to current keybindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ qrc_*.cpp
 ui_*.h
 qgit.pro.*
 qgit.qbs.*
+src/release
+.qmake.stash

--- a/README
+++ b/README
@@ -116,8 +116,8 @@ available commands and a 'quick jump' tag list.
 *Key bindings*::
 
 `-------------`----------------------------------
-r             Go to revisions list page
-p             Go to patch page
+<CTRL-r>      Go to revisions list page
+<CTRL-p>      Go to patch page
 f             Go to file page
 <Alt+wheel>   Go to next/previous page
 t             Toggle tree view

--- a/README
+++ b/README
@@ -116,8 +116,8 @@ available commands and a 'quick jump' tag list.
 *Key bindings*::
 
 `-------------`----------------------------------
-<CTRL-r>      Go to revisions list page
-<CTRL-p>      Go to patch page
+r             Go to revisions list page
+p             Go to patch page
 f             Go to file page
 <Alt+wheel>   Go to next/previous page
 t             Toggle tree view

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -1035,7 +1035,7 @@ void MainImpl::shortCutActivated() {
 		if (key == Qt::Key_I) {
 			rv->tab()->listViewLog->on_keyUp();
 		}
-		else if (key == (Qt::Key_K or key == Qt::Key_N)) {
+		else if ((key == Qt::Key_K) or (key == Qt::Key_N)) {
 			rv->tab()->listViewLog->on_keyDown();
 		}
 		else if (key == (Qt::SHIFT | Qt::Key_Up)) {


### PR DESCRIPTION
Hi

I noticed that in qgit-2.7 some of the key bindings did not work anymore. Especially n/k (to move down one revision) not working was quite annoing and prevented me from upgrading.

I also adjusted the readme to reflect the current keybindings for going to revisions page (r -> CTRL-r) and to the patch page (p -> CTRL-p). There might be different mismatches, but most keys I did try with the patched versions were doing what I expected.

Thanks and cheers
Urs