### PR TITLE
Extract ref name from QAction's iconText() instead of text()

### DIFF
--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -1372,7 +1372,7 @@ void MainImpl::goRef_triggered(QAction* act) {
 	if (!act || act->data() != "Ref")
 		return;
 
-	SCRef refSha(git->getRefSha(act->text()));
+	SCRef refSha(git->getRefSha(act->iconText()));
 	rv->st.setSha(refSha);
 	UPDATE_DOMAIN(rv);
 }


### PR DESCRIPTION
When selecting a branch on the context menu, the action text is supposed to have the ref name in it. In some cases, Qt mangles the text and inserts an ampersand (shortcut marker) on the triggered action (shortcuts are not shown in the UI). I don't know why Qt does this, this seems undocumented behavior. Due to the mangling, the ref obviously can't be found. By using iconText() instead of text(), Qt returns the text with ampersands removed.

As Qt is mangling texts, maybe a better fix would be to set the ref name into the userdata somewhere, but this quick fix works for me. It'll probably break on refnames with ampersands, but they should be rare.