### PR TITLE
Fixed browsing files history.

### DIFF
--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -250,7 +250,6 @@ void ListView::currentChanged(const QModelIndex& index, const QModelIndex&) {
 	SCRef selRev = sha(index.row());
 	if (st->sha() != selRev) { // to avoid looping
 		st->setSha(selRev);
-		st->setFileName("");
 		st->setSelectItem(true);
 		UPDATE_DOMAIN(d);
 	}

--- a/src/revsview.cpp
+++ b/src/revsview.cpp
@@ -280,7 +280,8 @@ bool RevsView::doUpdate(bool force) {
 		}
 		if (st.isChanged() || force) {
 			// activate log or diff tab depending on file selection
-			tab()->tabLogDiff->setCurrentIndex(st.fileName().isEmpty() ? 0 : 1);
+			bool sha_changed = st.sha(true) != st.sha(false);
+			tab()->tabLogDiff->setCurrentIndex(sha_changed ? 0 : 1);
 			tab()->textEditDiff->centerOnFileHeader(st);
 		}
 


### PR DESCRIPTION
This is a regression since 2fed338fd4c8c9bf147beeca7018ff2a946dbfb3.

We can't just clear current file name, because it's useful in some cases. For example if you browse commits for particular file that was selected in the left panel.

As far as I understand the goal is to open "Log" tab when different commit is pressed and open "Diff" tab when different filename is selected. This can be achieved by checking if sha has been changed.

Fixes #11