### PR TITLE
fixed recognition of detached branches

### DIFF
--- a/src/git.cpp
+++ b/src/git.cpp
@@ -1741,7 +1741,7 @@ bool Git::getRefs() {
         curBranchSHA = curBranchSHA.trimmed();
         curBranchName = curBranchName.prepend('\n').section("\n*", 1);
         curBranchName = curBranchName.section('\n', 0, 0).trimmed();
-        if (curBranchName.startsWith("(detached from"))
+        if (curBranchName.contains(" detached "))
             curBranchName = "";
 
         // read refs, normally unsorted


### PR DESCRIPTION
Obviously git changed the way how it reports detached branches. Not it reads like this:
`HEAD detached at ccfb057`

This PR fixes the detection in qgit.