### PR TITLE
Don't cast away const

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -388,8 +388,8 @@ public:
 	 */
 	QByteArray pathsIdx;
 
-	int dirAt(uint idx) const { return ((int*)pathsIdx.constData())[idx]; }
-	int nameAt(uint idx) const { return ((int*)pathsIdx.constData())[count() + idx]; }
+	int dirAt(uint idx) const { return ((const int*)pathsIdx.constData())[idx]; }
+	int nameAt(uint idx) const { return ((const int*)pathsIdx.constData())[count() + idx]; }
 
 	QVector<int> mergeParent;
 


### PR DESCRIPTION
Fix some C-style casts to not pointlessly strip away `const`-ness. This avoids tripping `-Wcast-qual`.