### PR TITLE
Fix: Use QFontDatabase::systemFont() for default fonts

### DIFF
--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -86,17 +86,26 @@ MainImpl::MainImpl(SCRef cd, QWidget* p) : QMainWindow(p) {
 	// set-up standard revisions and files list font
 	QSettings settings;
 	QString font(settings.value(STD_FNT_KEY).toString());
-	if (font.isEmpty())
+	if (font.isEmpty()) {
+	#if (QT_VERSION >= QT_VERSION_CHECK(5,2,0))
+		font = QFontDatabase::systemFont(QFontDatabase::GeneralFont).toString();
+	#else
 		font = QApplication::font().toString();
+	#endif
+	}
 	QGit::STD_FONT.fromString(font);
 
 	// set-up typewriter (fixed width) font
 	font = settings.value(TYPWRT_FNT_KEY).toString();
 	if (font.isEmpty()) { // choose a sensible default
+	#if (QT_VERSION >= QT_VERSION_CHECK(5,2,0))
+		QFont fnt = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+	#else
 		QFont fnt = QApplication::font();
 		fnt.setStyleHint(QFont::TypeWriter, QFont::PreferDefault);
 		fnt.setFixedPitch(true);
 		fnt.setFamily(fnt.defaultFamily()); // the family corresponding
+	#endif
 		font = fnt.toString();              // to current style hint
 	}
 	QGit::TYPE_WRITER_FONT.fromString(font);


### PR DESCRIPTION
When building for QT5.2 and later, use QFontDatabase::systemFont() to
retrieve the default fonts. This fixes two font issues on the MacOS:
* The fonts selected via QApplication::font() are not optimum and
  look very pixelated.
* QFont::setStyleHint() doesn't retrieve a valid font though
  QFont::setFixedPitch() enforces a fixed pitch. This results in
  an unreadable diff view.