### PR TITLE
UI: Fix marker generation on HiDPI displays

### DIFF
--- a/src/listview.h
+++ b/src/listview.h
@@ -104,6 +104,7 @@ private:
 	QPixmap* getTagMarks(SCRef sha, const QStyleOptionViewItem& opt) const;
 	void addTextPixmap(QPixmap** pp, SCRef txt, const QStyleOptionViewItem& opt) const;
 	bool changedFiles(SCRef sha) const;
+	const qreal dpr(void) const;
 
 	Git* git;
 	ListViewProxy* lp;


### PR DESCRIPTION
This patch fixes the markers generation when using HiDPI displays. The
previous implementation was mixing real pixels and device independent
pixels values when calculating sizes and spacing.