### PR TITLE
Use theme icons

### DIFF
--- a/src/console.ui
+++ b/src/console.ui
@@ -14,7 +14,7 @@
    <string>Action output window - QGit</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="icons.qrc">
+   <iconset theme="utilities-terminal" resource="icons.qrc">
     <normaloff>:/icons/resources/openterm.png</normaloff>:/icons/resources/openterm.png</iconset>
   </property>
   <widget class="QWidget" name="widget">
@@ -100,7 +100,7 @@
          <string>&amp;Terminate</string>
         </property>
         <property name="icon">
-         <iconset resource="icons.qrc">
+         <iconset theme="dialog-cancel" resource="icons.qrc">
           <normaloff>:/icons/resources/cancel.png</normaloff>:/icons/resources/cancel.png</iconset>
         </property>
         <property name="autoDefault">

--- a/src/console.ui
+++ b/src/console.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>Console</class>
- <widget class="QMainWindow" name="Console" >
-  <property name="geometry" >
+ <widget class="QMainWindow" name="Console">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,713 +10,291 @@
     <height>442</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Action output window - QGit</string>
   </property>
-  <property name="windowIcon" >
-   <iconset resource="icons.qrc" >:/icons/resources/openterm.png</iconset>
+  <property name="windowIcon">
+   <iconset resource="icons.qrc">
+    <normaloff>:/icons/resources/openterm.png</normaloff>:/icons/resources/openterm.png</iconset>
   </property>
-  <widget class="QWidget" name="widget" >
-   <layout class="QHBoxLayout" >
-    <property name="margin" >
-     <number>9</number>
-    </property>
-    <property name="spacing" >
-     <number>6</number>
-    </property>
+  <widget class="QWidget" name="widget">
+   <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <layout class="QVBoxLayout" >
-      <property name="margin" >
-       <number>0</number>
-      </property>
-      <property name="spacing" >
+     <layout class="QHBoxLayout">
+      <property name="spacing">
        <number>6</number>
       </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
-       <widget class="QFrame" name="frame_3" >
-        <property name="sizePolicy" >
-         <sizepolicy>
-          <hsizetype>5</hsizetype>
-          <vsizetype>1</vsizetype>
+       <widget class="QLabel" name="textLabelCmd">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>3</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <family>Sans Serif</family>
+          <pointsize>9</pointsize>
+          <weight>75</weight>
+          <italic>false</italic>
+          <bold>true</bold>
+          <underline>false</underline>
+          <strikeout>false</strikeout>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>Shows action definition</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButtonTerminate">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="minimumSize" >
-         <size>
-          <width>16</width>
-          <height>70</height>
-         </size>
+        <property name="toolTip">
+         <string>Click to terminate action execution</string>
         </property>
-        <property name="frameShape" >
-         <enum>QFrame::StyledPanel</enum>
+        <property name="text">
+         <string>&amp;Terminate</string>
         </property>
-        <property name="frameShadow" >
-         <enum>QFrame::Plain</enum>
+        <property name="icon">
+         <iconset resource="icons.qrc">
+          <normaloff>:/icons/resources/cancel.png</normaloff>:/icons/resources/cancel.png</iconset>
         </property>
-        <layout class="QHBoxLayout" >
-         <property name="margin" >
-          <number>9</number>
-         </property>
-         <property name="spacing" >
-          <number>6</number>
-         </property>
-         <item>
-          <layout class="QHBoxLayout" >
-           <property name="margin" >
-            <number>0</number>
-           </property>
-           <property name="spacing" >
-            <number>6</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="textLabelCmd" >
-             <property name="sizePolicy" >
-              <sizepolicy>
-               <hsizetype>5</hsizetype>
-               <vsizetype>5</vsizetype>
-               <horstretch>3</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="font" >
-              <font>
-               <family>Sans Serif</family>
-               <pointsize>9</pointsize>
-               <weight>75</weight>
-               <italic>false</italic>
-               <bold>true</bold>
-               <underline>false</underline>
-               <strikeout>false</strikeout>
-              </font>
-             </property>
-             <property name="toolTip" >
-              <string>Shows action definition</string>
-             </property>
-             <property name="text" >
-              <string>...</string>
-             </property>
-             <property name="textFormat" >
-              <enum>Qt::PlainText</enum>
-             </property>
-             <property name="alignment" >
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-             </property>
-             <property name="wordWrap" >
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer>
-             <property name="orientation" >
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" >
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="pushButtonTerminate" >
-             <property name="sizePolicy" >
-              <sizepolicy>
-               <hsizetype>1</hsizetype>
-               <vsizetype>0</vsizetype>
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip" >
-              <string>Click to terminate action execution</string>
-             </property>
-             <property name="text" >
-              <string>&amp;Terminate</string>
-             </property>
-             <property name="icon" >
-              <iconset resource="icons.qrc" >:/icons/resources/cancel.png</iconset>
-             </property>
-             <property name="flat" >
-              <bool>false</bool>
-             </property>
-             <property name="autoDefault">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
+        <property name="autoDefault">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
        </widget>
-      </item>
-      <item>
-       <widget class="QFrame" name="frame" >
-        <property name="frameShape" >
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow" >
-         <enum>QFrame::Plain</enum>
-        </property>
-        <layout class="QHBoxLayout" >
-         <property name="margin" >
-          <number>9</number>
-         </property>
-         <property name="spacing" >
-          <number>6</number>
-         </property>
-         <item>
-          <widget class="QTextEdit" name="textEditOutput" >
-           <property name="palette" >
-            <palette>
-             <active>
-              <colorrole role="WindowText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Button" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>221</red>
-                 <green>223</green>
-                 <blue>228</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Light" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Midlight" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Dark" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>85</red>
-                 <green>85</green>
-                 <blue>85</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Mid" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>199</red>
-                 <green>199</green>
-                 <blue>199</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Text" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>85</red>
-                 <green>255</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="BrightText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="ButtonText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Base" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Window" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>239</red>
-                 <green>239</green>
-                 <blue>239</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Shadow" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Highlight" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>103</red>
-                 <green>141</green>
-                 <blue>178</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="HighlightedText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Link" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>238</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="LinkVisited" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>82</red>
-                 <green>24</green>
-                 <blue>139</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="AlternateBase" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>232</red>
-                 <green>232</green>
-                 <blue>232</blue>
-                </color>
-               </brush>
-              </colorrole>
-             </active>
-             <inactive>
-              <colorrole role="WindowText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Button" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>221</red>
-                 <green>223</green>
-                 <blue>228</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Light" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Midlight" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Dark" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>85</red>
-                 <green>85</green>
-                 <blue>85</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Mid" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>199</red>
-                 <green>199</green>
-                 <blue>199</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Text" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>85</red>
-                 <green>255</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="BrightText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="ButtonText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Base" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Window" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>239</red>
-                 <green>239</green>
-                 <blue>239</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Shadow" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Highlight" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>103</red>
-                 <green>141</green>
-                 <blue>178</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="HighlightedText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Link" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>238</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="LinkVisited" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>82</red>
-                 <green>24</green>
-                 <blue>139</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="AlternateBase" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>232</red>
-                 <green>232</green>
-                 <blue>232</blue>
-                </color>
-               </brush>
-              </colorrole>
-             </inactive>
-             <disabled>
-              <colorrole role="WindowText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>128</red>
-                 <green>128</green>
-                 <blue>128</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Button" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>221</red>
-                 <green>223</green>
-                 <blue>228</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Light" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Midlight" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Dark" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>85</red>
-                 <green>85</green>
-                 <blue>85</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Mid" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>199</red>
-                 <green>199</green>
-                 <blue>199</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Text" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>199</red>
-                 <green>199</green>
-                 <blue>199</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="BrightText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="ButtonText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>128</red>
-                 <green>128</green>
-                 <blue>128</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Base" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>239</red>
-                 <green>239</green>
-                 <blue>239</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Window" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>239</red>
-                 <green>239</green>
-                 <blue>239</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Shadow" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Highlight" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>86</red>
-                 <green>117</green>
-                 <blue>148</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="HighlightedText" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>255</red>
-                 <green>255</green>
-                 <blue>255</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="Link" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>0</red>
-                 <green>0</green>
-                 <blue>238</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="LinkVisited" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>82</red>
-                 <green>24</green>
-                 <blue>139</blue>
-                </color>
-               </brush>
-              </colorrole>
-              <colorrole role="AlternateBase" >
-               <brush brushstyle="SolidPattern" >
-                <color alpha="255" >
-                 <red>232</red>
-                 <green>232</green>
-                 <blue>232</blue>
-                </color>
-               </brush>
-              </colorrole>
-             </disabled>
-            </palette>
-           </property>
-           <property name="acceptDrops" >
-            <bool>false</bool>
-           </property>
-           <property name="undoRedoEnabled" >
-            <bool>false</bool>
-           </property>
-           <property name="readOnly" >
-            <bool>true</bool>
-           </property>
-           <property name="acceptRichText" >
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" >
-        <property name="margin" >
-         <number>0</number>
-        </property>
-        <property name="spacing" >
-         <number>6</number>
-        </property>
-        <item>
-         <spacer>
-          <property name="orientation" >
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" >
-           <size>
-            <width>531</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonOk" >
-          <property name="sizePolicy" >
-           <sizepolicy>
-            <hsizetype>1</hsizetype>
-            <vsizetype>0</vsizetype>
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip" >
-           <string>Click to close window. Warning action will not be terminated if running</string>
-          </property>
-          <property name="text" >
-           <string>&amp;Ok</string>
-          </property>
-          <property name="autoDefault">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
       </item>
      </layout>
     </item>
+    <item>
+     <widget class="QTextEdit" name="textEditOutput">
+      <property name="palette">
+       <palette>
+        <active>
+         <colorrole role="Text">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>85</red>
+            <green>255</green>
+            <blue>0</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="BrightText">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="Base">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="Highlight">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>103</red>
+            <green>141</green>
+            <blue>178</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="HighlightedText">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </brush>
+         </colorrole>
+        </active>
+        <inactive>
+         <colorrole role="Text">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>85</red>
+            <green>255</green>
+            <blue>0</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="BrightText">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="Base">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="Highlight">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>103</red>
+            <green>141</green>
+            <blue>178</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="HighlightedText">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </brush>
+         </colorrole>
+        </inactive>
+        <disabled>
+         <colorrole role="Text">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>199</red>
+            <green>199</green>
+            <blue>199</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="BrightText">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="Base">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>239</red>
+            <green>239</green>
+            <blue>239</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="Highlight">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>86</red>
+            <green>117</green>
+            <blue>148</blue>
+           </color>
+          </brush>
+         </colorrole>
+         <colorrole role="HighlightedText">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </brush>
+         </colorrole>
+        </disabled>
+       </palette>
+      </property>
+      <property name="acceptDrops">
+       <bool>false</bool>
+      </property>
+      <property name="undoRedoEnabled">
+       <bool>false</bool>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+      <property name="acceptRichText">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QDialogButtonBox" name="buttonBox">
+      <property name="standardButtons">
+       <set>QDialogButtonBox::Close</set>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
-  <action name="actionTerminate" >
-   <property name="text" >
+  <action name="actionTerminate">
+   <property name="text">
     <string>Terminate</string>
    </property>
   </action>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <tabstops>
   <tabstop>pushButtonTerminate</tabstop>
-  <tabstop>pushButtonOk</tabstop>
-  <tabstop>textEditOutput</tabstop>
  </tabstops>
  <resources>
-  <include location="icons.qrc" />
+  <include location="icons.qrc"/>
  </resources>
  <connections>
   <connection>
@@ -724,27 +303,27 @@
    <receiver>Console</receiver>
    <slot>pushButtonTerminate_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>658</x>
      <y>49</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>361</x>
      <y>220</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>pushButtonOk</sender>
-   <signal>clicked()</signal>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
    <receiver>Console</receiver>
    <slot>pushButtonOk_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
-     <x>658</x>
-     <y>404</y>
+    <hint type="sourcelabel">
+     <x>361</x>
+     <y>374</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>361</x>
      <y>220</y>
     </hint>

--- a/src/customaction.ui
+++ b/src/customaction.ui
@@ -14,7 +14,7 @@
    <string>Actions builder</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="icons.qrc">
+   <iconset theme="bookmarks" resource="icons.qrc">
     <normaloff>:/icons/resources/bookmark.png</normaloff>:/icons/resources/bookmark.png</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -39,7 +39,7 @@
          <string>&amp;New</string>
         </property>
         <property name="icon">
-         <iconset resource="icons.qrc">
+         <iconset theme="bookmark-new" resource="icons.qrc">
           <normaloff>:/icons/resources/bookmark_add.png</normaloff>:/icons/resources/bookmark_add.png</iconset>
         </property>
         <property name="shortcut">
@@ -53,7 +53,7 @@
          <string>&amp;Rename</string>
         </property>
         <property name="icon">
-         <iconset resource="icons.qrc">
+         <iconset theme="edit-rename" resource="icons.qrc">
           <normaloff>:/icons/resources/pencil.png</normaloff>:/icons/resources/pencil.png</iconset>
         </property>
         <property name="shortcut">
@@ -67,7 +67,7 @@
          <string>R&amp;emove</string>
         </property>
         <property name="icon">
-         <iconset resource="icons.qrc">
+         <iconset theme="edit-delete" resource="icons.qrc">
           <normaloff>:/icons/resources/remove.png</normaloff>:/icons/resources/remove.png</iconset>
         </property>
         <property name="shortcut">
@@ -84,7 +84,7 @@
          <string>Move &amp;up</string>
         </property>
         <property name="icon">
-         <iconset resource="icons.qrc">
+         <iconset theme="arrow-up" resource="icons.qrc">
           <normaloff>:/icons/resources/1uparrow.png</normaloff>:/icons/resources/1uparrow.png</iconset>
         </property>
         <property name="shortcut">
@@ -98,7 +98,7 @@
          <string>Move &amp;down</string>
         </property>
         <property name="icon">
-         <iconset resource="icons.qrc">
+         <iconset theme="arrow-down" resource="icons.qrc">
           <normaloff>:/icons/resources/1downarrow.png</normaloff>:/icons/resources/1downarrow.png</iconset>
         </property>
         <property name="shortcut">

--- a/src/customaction.ui
+++ b/src/customaction.ui
@@ -1,403 +1,214 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>CustomActionBase</class>
- <widget class="QWidget" name="CustomActionBase" >
-  <property name="geometry" >
+ <widget class="QWidget" name="CustomActionBase">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>564</width>
+    <width>579</width>
     <height>492</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Actions builder</string>
   </property>
-  <property name="windowIcon" >
-   <iconset resource="icons.qrc" >:/icons/resources/bookmark.png</iconset>
+  <property name="windowIcon">
+   <iconset resource="icons.qrc">
+    <normaloff>:/icons/resources/bookmark.png</normaloff>:/icons/resources/bookmark.png</iconset>
   </property>
-  <layout class="QHBoxLayout" >
-   <property name="spacing" >
-    <number>0</number>
-   </property>
-   <property name="leftMargin" >
-    <number>5</number>
-   </property>
-   <property name="topMargin" >
-    <number>5</number>
-   </property>
-   <property name="rightMargin" >
-    <number>5</number>
-   </property>
-   <property name="bottomMargin" >
-    <number>5</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" >
-     <property name="spacing" >
-      <number>6</number>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="leftMargin" >
-      <number>0</number>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
-     <property name="topMargin" >
-      <number>0</number>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
      </property>
-     <property name="rightMargin" >
-      <number>0</number>
-     </property>
-     <property name="bottomMargin" >
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QFrame" name="frame" >
-       <property name="sizePolicy" >
-        <sizepolicy vsizetype="Fixed" hsizetype="Preferred" >
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="frameShape" >
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow" >
-        <enum>QFrame::Raised</enum>
-       </property>
-       <layout class="QHBoxLayout" >
-        <property name="spacing" >
-         <number>6</number>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="pushButtonNew">
+        <property name="text">
+         <string>&amp;New</string>
         </property>
-        <property name="leftMargin" >
-         <number>9</number>
+        <property name="icon">
+         <iconset resource="icons.qrc">
+          <normaloff>:/icons/resources/bookmark_add.png</normaloff>:/icons/resources/bookmark_add.png</iconset>
         </property>
-        <property name="topMargin" >
-         <number>9</number>
+        <property name="shortcut">
+         <string>Alt+N</string>
         </property>
-        <property name="rightMargin" >
-         <number>9</number>
-        </property>
-        <property name="bottomMargin" >
-         <number>9</number>
-        </property>
-        <item>
-         <layout class="QHBoxLayout" >
-          <property name="spacing" >
-           <number>15</number>
-          </property>
-          <property name="leftMargin" >
-           <number>0</number>
-          </property>
-          <property name="topMargin" >
-           <number>0</number>
-          </property>
-          <property name="rightMargin" >
-           <number>0</number>
-          </property>
-          <property name="bottomMargin" >
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QPushButton" name="pushButtonNew" >
-            <property name="text" >
-             <string>&amp;New</string>
-            </property>
-            <property name="icon" >
-             <iconset resource="icons.qrc" >:/icons/resources/bookmark_add.png</iconset>
-            </property>
-            <property name="shortcut" >
-             <string>Alt+N</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pushButtonRename" >
-            <property name="text" >
-             <string>&amp;Rename</string>
-            </property>
-            <property name="icon" >
-             <iconset resource="icons.qrc" >:/icons/resources/pencil.png</iconset>
-            </property>
-            <property name="shortcut" >
-             <string>Alt+R</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pushButtonRemove" >
-            <property name="text" >
-             <string>R&amp;emove</string>
-            </property>
-            <property name="icon" >
-             <iconset resource="icons.qrc" >:/icons/resources/remove.png</iconset>
-            </property>
-            <property name="shortcut" >
-             <string>Alt+E</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pushButtonMoveUp" >
-            <property name="layoutDirection" >
-             <enum>Qt::LeftToRight</enum>
-            </property>
-            <property name="text" >
-             <string>Move &amp;up</string>
-            </property>
-            <property name="icon" >
-             <iconset resource="icons.qrc" >:/icons/resources/1uparrow.png</iconset>
-            </property>
-            <property name="shortcut" >
-             <string>Alt+U</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pushButtonMoveDown" >
-            <property name="text" >
-             <string>Move &amp;down</string>
-            </property>
-            <property name="icon" >
-             <iconset resource="icons.qrc" >:/icons/resources/1downarrow.png</iconset>
-            </property>
-            <property name="shortcut" >
-             <string>Alt+D</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSplitter" name="splitter" >
-       <property name="sizePolicy" >
-        <sizepolicy vsizetype="Expanding" hsizetype="Expanding" >
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="orientation" >
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <widget class="QFrame" name="frame_3" >
-        <property name="frameShape" >
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow" >
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QHBoxLayout" >
-         <property name="spacing" >
-          <number>6</number>
-         </property>
-         <property name="leftMargin" >
-          <number>9</number>
-         </property>
-         <property name="topMargin" >
-          <number>9</number>
-         </property>
-         <property name="rightMargin" >
-          <number>9</number>
-         </property>
-         <property name="bottomMargin" >
-          <number>9</number>
-         </property>
-         <item>
-          <layout class="QVBoxLayout" >
-           <property name="spacing" >
-            <number>6</number>
-           </property>
-           <property name="leftMargin" >
-            <number>0</number>
-           </property>
-           <property name="topMargin" >
-            <number>0</number>
-           </property>
-           <property name="rightMargin" >
-            <number>0</number>
-           </property>
-           <property name="bottomMargin" >
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="labelActionName" >
-             <property name="text" >
-              <string>Name</string>
-             </property>
-             <property name="buddy" >
-              <cstring>listWidgetNames</cstring>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QListWidget" name="listWidgetNames" />
-           </item>
-          </layout>
-         </item>
-        </layout>
        </widget>
-       <widget class="QFrame" name="frame_2" >
-        <property name="frameShape" >
-         <enum>QFrame::StyledPanel</enum>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButtonRename">
+        <property name="text">
+         <string>&amp;Rename</string>
         </property>
-        <property name="frameShadow" >
-         <enum>QFrame::Raised</enum>
+        <property name="icon">
+         <iconset resource="icons.qrc">
+          <normaloff>:/icons/resources/pencil.png</normaloff>:/icons/resources/pencil.png</iconset>
         </property>
-        <layout class="QHBoxLayout" >
-         <property name="spacing" >
-          <number>6</number>
-         </property>
-         <property name="leftMargin" >
-          <number>9</number>
-         </property>
-         <property name="topMargin" >
-          <number>9</number>
-         </property>
-         <property name="rightMargin" >
-          <number>9</number>
-         </property>
-         <property name="bottomMargin" >
-          <number>9</number>
-         </property>
-         <item>
-          <layout class="QVBoxLayout" >
-           <property name="spacing" >
-            <number>6</number>
-           </property>
-           <property name="leftMargin" >
-            <number>0</number>
-           </property>
-           <property name="topMargin" >
-            <number>0</number>
-           </property>
-           <property name="rightMargin" >
-            <number>0</number>
-           </property>
-           <property name="bottomMargin" >
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="textLabel1" >
-             <property name="text" >
-              <string>Insert commands to run:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QTextEdit" name="textEditAction" >
-             <property name="toolTip" >
-              <string>Insert commands to run. See handbook (F1) for some examples.</string>
-             </property>
-             <property name="acceptRichText" >
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Inserting tokens of the form %lineedit:arguments=defaults%
-will open a dialog to enter arguments. Additionally, you can use
-variables $CURRENT_BRANCH and $SHA.</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="checkBoxRefreshAfterAction">
-             <property name="toolTip">
-              <string>If checked main view will be automatically refreshed when done</string>
-             </property>
-             <property name="text">
-              <string>Refresh &amp;view at the end</string>
-             </property>
-             <property name="shortcut">
-              <string>Alt+V</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" >
-             <property name="spacing" >
-              <number>6</number>
-             </property>
-             <property name="leftMargin" >
-              <number>0</number>
-             </property>
-             <property name="topMargin" >
-              <number>0</number>
-             </property>
-             <property name="rightMargin" >
-              <number>0</number>
-             </property>
-             <property name="bottomMargin" >
-              <number>0</number>
-             </property>
-            </layout>
-           </item>
-          </layout>
-         </item>
-        </layout>
+        <property name="shortcut">
+         <string>Alt+R</string>
+        </property>
        </widget>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" >
-       <property name="spacing" >
-        <number>6</number>
-       </property>
-       <property name="leftMargin" >
-        <number>0</number>
-       </property>
-       <property name="topMargin" >
-        <number>0</number>
-       </property>
-       <property name="rightMargin" >
-        <number>0</number>
-       </property>
-       <property name="bottomMargin" >
-        <number>0</number>
-       </property>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButtonRemove">
+        <property name="text">
+         <string>R&amp;emove</string>
+        </property>
+        <property name="icon">
+         <iconset resource="icons.qrc">
+          <normaloff>:/icons/resources/remove.png</normaloff>:/icons/resources/remove.png</iconset>
+        </property>
+        <property name="shortcut">
+         <string>Alt+E</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButtonMoveUp">
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>Move &amp;up</string>
+        </property>
+        <property name="icon">
+         <iconset resource="icons.qrc">
+          <normaloff>:/icons/resources/1uparrow.png</normaloff>:/icons/resources/1uparrow.png</iconset>
+        </property>
+        <property name="shortcut">
+         <string>Alt+U</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButtonMoveDown">
+        <property name="text">
+         <string>Move &amp;down</string>
+        </property>
+        <property name="icon">
+         <iconset resource="icons.qrc">
+          <normaloff>:/icons/resources/1downarrow.png</normaloff>:/icons/resources/1downarrow.png</iconset>
+        </property>
+        <property name="shortcut">
+         <string>Alt+D</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QFrame" name="frame_3">
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <spacer>
-         <property name="orientation" >
-          <enum>Qt::Horizontal</enum>
+        <widget class="QLabel" name="labelActionName">
+         <property name="text">
+          <string>&amp;Name</string>
          </property>
-         <property name="sizeType" >
-          <enum>QSizePolicy::Expanding</enum>
+         <property name="buddy">
+          <cstring>listWidgetNames</cstring>
          </property>
-         <property name="sizeHint" >
-          <size>
-           <width>101</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
+        </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="pushButtonOk" >
-         <property name="text" >
-          <string>&amp;Ok</string>
+        <widget class="QListWidget" name="listWidgetNames"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QFrame" name="frame_2">
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="textLabel1">
+         <property name="text">
+          <string>Insert commands to run:</string>
          </property>
-         <property name="shortcut" >
-          <string>Alt+O</string>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTextEdit" name="textEditAction">
+         <property name="toolTip">
+          <string>Insert commands to run. See handbook (F1) for some examples.</string>
          </property>
-         <property name="autoDefault" >
-          <bool>true</bool>
+         <property name="acceptRichText">
+          <bool>false</bool>
          </property>
-         <property name="default" >
-          <bool>true</bool>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Inserting tokens of the form &lt;code&gt;%lineedit:arguments=defaults%&lt;/code&gt;&lt;br/&gt;
+will open a dialog to enter arguments. Additionally, you can use&lt;br/&gt;
+variables &lt;code&gt;$CURRENT_BRANCH&lt;/code&gt; and &lt;code&gt;$SHA&lt;/code&gt;.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBoxRefreshAfterAction">
+         <property name="toolTip">
+          <string>If checked main view will be automatically refreshed when done</string>
+         </property>
+         <property name="text">
+          <string>Refresh &amp;view at the end</string>
+         </property>
+         <property name="shortcut">
+          <string>Alt+V</string>
          </property>
         </widget>
        </item>
       </layout>
-     </item>
-    </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <resources>
-  <include location="icons.qrc" />
+  <include location="icons.qrc"/>
  </resources>
  <connections>
   <connection>
@@ -406,11 +217,11 @@ variables $CURRENT_BRANCH and $SHA.</string>
    <receiver>CustomActionBase</receiver>
    <slot>pushButtonNew_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -422,11 +233,11 @@ variables $CURRENT_BRANCH and $SHA.</string>
    <receiver>CustomActionBase</receiver>
    <slot>pushButtonRename_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -438,11 +249,11 @@ variables $CURRENT_BRANCH and $SHA.</string>
    <receiver>CustomActionBase</receiver>
    <slot>pushButtonRemove_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -454,11 +265,11 @@ variables $CURRENT_BRANCH and $SHA.</string>
    <receiver>CustomActionBase</receiver>
    <slot>checkBoxRefreshAfterAction_toggled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -470,11 +281,11 @@ variables $CURRENT_BRANCH and $SHA.</string>
    <receiver>CustomActionBase</receiver>
    <slot>pushButtonMoveUp_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -486,27 +297,11 @@ variables $CURRENT_BRANCH and $SHA.</string>
    <receiver>CustomActionBase</receiver>
    <slot>pushButtonMoveDown_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>pushButtonOk</sender>
-   <signal>clicked()</signal>
-   <receiver>CustomActionBase</receiver>
-   <slot>pushButtonOk_clicked()</slot>
-   <hints>
-    <hint type="sourcelabel" >
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -518,11 +313,11 @@ variables $CURRENT_BRANCH and $SHA.</string>
    <receiver>CustomActionBase</receiver>
    <slot>textEditAction_textChanged()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>395</x>
      <y>239</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>330</x>
      <y>231</y>
     </hint>
@@ -534,13 +329,29 @@ variables $CURRENT_BRANCH and $SHA.</string>
    <receiver>CustomActionBase</receiver>
    <slot>listWidgetNames_currentItemChanged(QListWidgetItem*,QListWidgetItem*)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>129</x>
      <y>256</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>337</x>
      <y>232</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>CustomActionBase</receiver>
+   <slot>pushButtonOk_clicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>289</x>
+     <y>428</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>289</x>
+     <y>245</y>
     </hint>
    </hints>
   </connection>

--- a/src/fileview.ui
+++ b/src/fileview.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>TabFile</class>
- <widget class="QWidget" name="TabFile" >
-  <property name="geometry" >
+ <widget class="QWidget" name="TabFile">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,225 +10,232 @@
     <height>480</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>File</string>
   </property>
-  <layout class="QHBoxLayout" >
-   <property name="spacing" >
+  <layout class="QHBoxLayout">
+   <property name="spacing">
     <number>0</number>
    </property>
-   <property name="leftMargin" >
+   <property name="leftMargin">
     <number>0</number>
    </property>
-   <property name="topMargin" >
+   <property name="topMargin">
     <number>0</number>
    </property>
-   <property name="rightMargin" >
+   <property name="rightMargin">
     <number>0</number>
    </property>
-   <property name="bottomMargin" >
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
-    <layout class="QVBoxLayout" >
-     <property name="spacing" >
+    <layout class="QVBoxLayout">
+     <property name="spacing">
       <number>0</number>
      </property>
-     <property name="leftMargin" >
+     <property name="leftMargin">
       <number>0</number>
      </property>
-     <property name="topMargin" >
+     <property name="topMargin">
       <number>0</number>
      </property>
-     <property name="rightMargin" >
+     <property name="rightMargin">
       <number>0</number>
      </property>
-     <property name="bottomMargin" >
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
-      <layout class="QHBoxLayout" >
-       <property name="spacing" >
+      <layout class="QHBoxLayout">
+       <property name="spacing">
         <number>0</number>
        </property>
-       <property name="leftMargin" >
+       <property name="leftMargin">
         <number>0</number>
        </property>
-       <property name="topMargin" >
+       <property name="topMargin">
         <number>0</number>
        </property>
-       <property name="rightMargin" >
+       <property name="rightMargin">
         <number>0</number>
        </property>
-       <property name="bottomMargin" >
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
-        <widget class="QToolButton" name="toolButtonCopy" >
-         <property name="minimumSize" >
+        <widget class="QToolButton" name="toolButtonCopy">
+         <property name="minimumSize">
           <size>
            <width>30</width>
            <height>30</height>
           </size>
          </property>
-         <property name="toolTip" >
+         <property name="toolTip">
           <string>Copy selection to the clipboard stripping line headers (CTRL+C)</string>
          </property>
-         <property name="icon" >
-          <iconset resource="icons.qrc" >:/icons/resources/editcopy.png</iconset>
+         <property name="icon">
+          <iconset theme="edit-copy" resource="icons.qrc">
+           <normaloff>:/icons/resources/editcopy.png</normaloff>:/icons/resources/editcopy.png</iconset>
          </property>
-         <property name="shortcut" >
+         <property name="shortcut">
           <string>Ctrl+C</string>
          </property>
-         <property name="autoRaise" >
+         <property name="autoRaise">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QToolButton" name="toolButtonShowAnnotate" >
-         <property name="enabled" >
+        <widget class="QToolButton" name="toolButtonShowAnnotate">
+         <property name="enabled">
           <bool>false</bool>
          </property>
-         <property name="minimumSize" >
+         <property name="minimumSize">
           <size>
            <width>30</width>
            <height>30</height>
           </size>
          </property>
-         <property name="toolTip" >
+         <property name="toolTip">
           <string>Hide/show file annotation</string>
          </property>
-         <property name="icon" >
-          <iconset resource="icons.qrc" >:/icons/resources/view_choose.png</iconset>
+         <property name="icon">
+          <iconset theme="view-sidetree" resource="icons.qrc">
+           <normaloff>:/icons/resources/view_choose.png</normaloff>:/icons/resources/view_choose.png</iconset>
          </property>
-         <property name="checkable" >
+         <property name="checkable">
           <bool>true</bool>
          </property>
-         <property name="checked" >
+         <property name="checked">
           <bool>true</bool>
          </property>
-         <property name="autoRaise" >
+         <property name="autoRaise">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QToolButton" name="toolButtonFindAnnotate" >
-         <property name="enabled" >
+        <widget class="QToolButton" name="toolButtonFindAnnotate">
+         <property name="enabled">
           <bool>false</bool>
          </property>
-         <property name="minimumSize" >
+         <property name="minimumSize">
           <size>
            <width>30</width>
            <height>30</height>
           </size>
          </property>
-         <property name="toolTip" >
+         <property name="toolTip">
           <string>Lock selection to first tagged line of current revision (CTRL + L)</string>
          </property>
-         <property name="icon" >
-          <iconset resource="icons.qrc" >:/icons/resources/encrypted.png</iconset>
+         <property name="icon">
+          <iconset theme="object-locked" resource="icons.qrc">
+           <normaloff>:/icons/resources/encrypted.png</normaloff>:/icons/resources/encrypted.png</iconset>
          </property>
-         <property name="checkable" >
+         <property name="checkable">
           <bool>true</bool>
          </property>
-         <property name="autoRaise" >
+         <property name="autoRaise">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QToolButton" name="toolButtonGoPrev" >
-         <property name="enabled" >
+        <widget class="QToolButton" name="toolButtonGoPrev">
+         <property name="enabled">
           <bool>false</bool>
          </property>
-         <property name="toolTip" >
+         <property name="toolTip">
           <string>Go to previous annotation line</string>
          </property>
-         <property name="icon" >
-          <iconset resource="icons.qrc" >:/icons/resources/1uparrow.png</iconset>
+         <property name="icon">
+          <iconset theme="go-previous" resource="icons.qrc">
+           <normaloff>:/icons/resources/1uparrow.png</normaloff>:/icons/resources/1uparrow.png</iconset>
          </property>
-         <property name="autoRaise" >
+         <property name="autoRaise">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QToolButton" name="toolButtonGoNext" >
-         <property name="enabled" >
+        <widget class="QToolButton" name="toolButtonGoNext">
+         <property name="enabled">
           <bool>false</bool>
          </property>
-         <property name="toolTip" >
+         <property name="toolTip">
           <string>Go to next annotation line</string>
          </property>
-         <property name="icon" >
-          <iconset resource="icons.qrc" >:/icons/resources/1downarrow.png</iconset>
+         <property name="icon">
+          <iconset theme="go-next" resource="icons.qrc">
+           <normaloff>:/icons/resources/1downarrow.png</normaloff>:/icons/resources/1downarrow.png</iconset>
          </property>
-         <property name="autoRaise" >
+         <property name="autoRaise">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QToolButton" name="toolButtonRangeFilter" >
-         <property name="enabled" >
+        <widget class="QToolButton" name="toolButtonRangeFilter">
+         <property name="enabled">
           <bool>false</bool>
          </property>
-         <property name="minimumSize" >
+         <property name="minimumSize">
           <size>
            <width>30</width>
            <height>30</height>
           </size>
          </property>
-         <property name="toolTip" >
+         <property name="toolTip">
           <string>Filter revisions on selected line range</string>
          </property>
-         <property name="icon" >
-          <iconset resource="icons.qrc" >:/icons/resources/filter.png</iconset>
+         <property name="icon">
+          <iconset theme="view-filter" resource="icons.qrc">
+           <normaloff>:/icons/resources/filter.png</normaloff>:/icons/resources/filter.png</iconset>
          </property>
-         <property name="checkable" >
+         <property name="checkable">
           <bool>true</bool>
          </property>
-         <property name="autoRaise" >
+         <property name="autoRaise">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QToolButton" name="toolButtonHighlightText" >
-         <property name="enabled" >
+        <widget class="QToolButton" name="toolButtonHighlightText">
+         <property name="enabled">
           <bool>false</bool>
          </property>
-         <property name="minimumSize" >
+         <property name="minimumSize">
           <size>
            <width>30</width>
            <height>30</height>
           </size>
          </property>
-         <property name="toolTip" >
+         <property name="toolTip">
           <string>Source highlight (%1)</string>
          </property>
-         <property name="icon" >
-          <iconset resource="icons.qrc" >:/icons/resources/colorize.png</iconset>
+         <property name="icon">
+          <iconset theme="format-text-color" resource="icons.qrc">
+           <normaloff>:/icons/resources/colorize.png</normaloff>:/icons/resources/colorize.png</iconset>
          </property>
-         <property name="checkable" >
+         <property name="checkable">
           <bool>true</bool>
          </property>
-         <property name="autoRaise" >
+         <property name="autoRaise">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
         <spacer>
-         <property name="orientation" >
+         <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
-         <property name="sizeType" >
+         <property name="sizeType">
           <enum>QSizePolicy::Expanding</enum>
          </property>
-         <property name="sizeHint" >
+         <property name="sizeHint" stdset="0">
           <size>
            <width>300</width>
            <height>20</height>
@@ -236,68 +244,69 @@
         </spacer>
        </item>
        <item>
-        <widget class="QFrame" name="frame" >
-         <property name="frameShape" >
+        <widget class="QFrame" name="frame">
+         <property name="frameShape">
           <enum>QFrame::StyledPanel</enum>
          </property>
-         <property name="frameShadow" >
+         <property name="frameShadow">
           <enum>QFrame::Raised</enum>
          </property>
-         <layout class="QHBoxLayout" >
-          <property name="spacing" >
+         <layout class="QHBoxLayout">
+          <property name="spacing">
            <number>0</number>
           </property>
-          <property name="leftMargin" >
+          <property name="leftMargin">
            <number>2</number>
           </property>
-          <property name="topMargin" >
+          <property name="topMargin">
            <number>2</number>
           </property>
-          <property name="rightMargin" >
+          <property name="rightMargin">
            <number>2</number>
           </property>
-          <property name="bottomMargin" >
+          <property name="bottomMargin">
            <number>2</number>
           </property>
           <item>
-           <layout class="QHBoxLayout" >
-            <property name="spacing" >
+           <layout class="QHBoxLayout">
+            <property name="spacing">
              <number>0</number>
             </property>
-            <property name="leftMargin" >
+            <property name="leftMargin">
              <number>0</number>
             </property>
-            <property name="topMargin" >
+            <property name="topMargin">
              <number>0</number>
             </property>
-            <property name="rightMargin" >
+            <property name="rightMargin">
              <number>0</number>
             </property>
-            <property name="bottomMargin" >
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
-             <widget class="QToolButton" name="toolButtonPin" >
-              <property name="toolTip" >
+             <widget class="QToolButton" name="toolButtonPin">
+              <property name="toolTip">
                <string>Pin View (Alt-V)</string>
               </property>
-              <property name="text" >
+              <property name="text">
                <string/>
               </property>
-              <property name="icon" >
-               <iconset resource="icons.qrc" >:/icons/resources/ok.png</iconset>
+              <property name="icon">
+               <iconset theme="dialog-ok-apply" resource="icons.qrc">
+                <normaloff>:/icons/resources/ok.png</normaloff>:/icons/resources/ok.png</iconset>
               </property>
-              <property name="checkable" >
+              <property name="checkable">
                <bool>true</bool>
               </property>
-              <property name="autoRaise" >
+              <property name="autoRaise">
                <bool>true</bool>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QSpinBox" name="spinBoxRevision" >
-              <property name="maximum" >
+             <widget class="QSpinBox" name="spinBoxRevision">
+              <property name="maximum">
                <number>65535</number>
               </property>
              </widget>
@@ -310,101 +319,101 @@
       </layout>
      </item>
      <item>
-      <widget class="QSplitter" name="splitter" >
-       <property name="orientation" >
+      <widget class="QSplitter" name="splitter">
+       <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
-       <widget class="ListView" name="histListView" >
-        <property name="contextMenuPolicy" >
+       <widget class="ListView" name="histListView">
+        <property name="contextMenuPolicy">
          <enum>Qt::CustomContextMenu</enum>
         </property>
-        <property name="alternatingRowColors" >
+        <property name="alternatingRowColors">
          <bool>true</bool>
         </property>
-        <property name="rootIsDecorated" >
+        <property name="rootIsDecorated">
          <bool>false</bool>
         </property>
-        <property name="uniformRowHeights" >
+        <property name="uniformRowHeights">
          <bool>true</bool>
         </property>
-        <property name="itemsExpandable" >
+        <property name="itemsExpandable">
          <bool>false</bool>
         </property>
-        <property name="allColumnsShowFocus" >
+        <property name="allColumnsShowFocus">
          <bool>true</bool>
         </property>
        </widget>
-       <widget class="QFrame" name="frame_2" >
-        <property name="frameShape" >
+       <widget class="QFrame" name="frame_2">
+        <property name="frameShape">
          <enum>QFrame::StyledPanel</enum>
         </property>
-        <property name="frameShadow" >
+        <property name="frameShadow">
          <enum>QFrame::Sunken</enum>
         </property>
-        <layout class="QHBoxLayout" >
-         <property name="spacing" >
+        <layout class="QHBoxLayout">
+         <property name="spacing">
           <number>0</number>
          </property>
-         <property name="leftMargin" >
+         <property name="leftMargin">
           <number>0</number>
          </property>
-         <property name="topMargin" >
+         <property name="topMargin">
           <number>0</number>
          </property>
-         <property name="rightMargin" >
+         <property name="rightMargin">
           <number>0</number>
          </property>
-         <property name="bottomMargin" >
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
-          <layout class="QHBoxLayout" >
-           <property name="spacing" >
+          <layout class="QHBoxLayout">
+           <property name="spacing">
             <number>1</number>
            </property>
-           <property name="leftMargin" >
+           <property name="leftMargin">
             <number>0</number>
            </property>
-           <property name="topMargin" >
+           <property name="topMargin">
             <number>0</number>
            </property>
-           <property name="rightMargin" >
+           <property name="rightMargin">
             <number>0</number>
            </property>
-           <property name="bottomMargin" >
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
-            <widget class="QListWidget" name="listWidgetAnn" >
-             <property name="frameShape" >
+            <widget class="QListWidget" name="listWidgetAnn">
+             <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
-             <property name="verticalScrollBarPolicy" >
+             <property name="verticalScrollBarPolicy">
               <enum>Qt::ScrollBarAlwaysOff</enum>
              </property>
-             <property name="horizontalScrollBarPolicy" >
+             <property name="horizontalScrollBarPolicy">
               <enum>Qt::ScrollBarAlwaysOff</enum>
              </property>
-             <property name="verticalScrollMode" >
+             <property name="verticalScrollMode">
               <enum>QAbstractItemView::ScrollPerPixel</enum>
              </property>
-             <property name="horizontalScrollMode" >
+             <property name="horizontalScrollMode">
               <enum>QAbstractItemView::ScrollPerPixel</enum>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="FileContent" name="textEditFile" >
-             <property name="frameShape" >
+            <widget class="FileContent" name="textEditFile">
+             <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
              </property>
-             <property name="undoRedoEnabled" >
+             <property name="undoRedoEnabled">
               <bool>false</bool>
              </property>
-             <property name="lineWrapMode" >
+             <property name="lineWrapMode">
               <enum>QTextEdit::NoWrap</enum>
              </property>
-             <property name="readOnly" >
+             <property name="readOnly">
               <bool>true</bool>
              </property>
             </widget>
@@ -419,7 +428,7 @@
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
    <class>ListView</class>
@@ -433,7 +442,7 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="icons.qrc" />
+  <include location="icons.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/help.ui
+++ b/src/help.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>HelpBase</class>
- <widget class="QWidget" name="HelpBase" >
-  <property name="geometry" >
+ <widget class="QWidget" name="HelpBase">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,112 +10,56 @@
     <height>451</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Help</string>
   </property>
-  <property name="windowIcon" >
-   <iconset resource="icons.qrc" >:/icons/resources/help.png</iconset>
+  <property name="windowIcon">
+   <iconset resource="icons.qrc">
+    <normaloff>:/icons/resources/help.png</normaloff>:/icons/resources/help.png</iconset>
   </property>
-  <layout class="QHBoxLayout" >
-   <property name="margin" >
-    <number>0</number>
-   </property>
-   <property name="spacing" >
-    <number>0</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" >
-     <property name="margin" >
-      <number>0</number>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="spacing" >
-      <number>5</number>
+     <widget class="QTextEdit" name="textEditHelp">
+      <property name="undoRedoEnabled">
+       <bool>false</bool>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
      </property>
-     <item>
-      <widget class="QSplitter" name="splitter" >
-       <property name="orientation" >
-        <enum>Qt::Vertical</enum>
-       </property>
-       <widget class="QTextEdit" name="textEditHelp" >
-        <property name="undoRedoEnabled" >
-         <bool>false</bool>
-        </property>
-        <property name="readOnly" >
-         <bool>true</bool>
-        </property>
-       </widget>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" >
-       <property name="margin" >
-        <number>0</number>
-       </property>
-       <property name="spacing" >
-        <number>6</number>
-       </property>
-       <item>
-        <spacer>
-         <property name="orientation" >
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType" >
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" >
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="buttonOk" >
-         <property name="minimumSize" >
-          <size>
-           <width>80</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text" >
-          <string>O&amp;K</string>
-         </property>
-         <property name="shortcut" >
-          <string>Alt+K</string>
-         </property>
-         <property name="autoDefault" >
-          <bool>true</bool>
-         </property>
-         <property name="default" >
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
+    </widget>
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <resources>
-  <include location="icons.qrc" />
+  <include location="icons.qrc"/>
  </resources>
  <connections>
   <connection>
-   <sender>buttonOk</sender>
-   <signal>clicked()</signal>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
    <receiver>HelpBase</receiver>
    <slot>close()</slot>
    <hints>
-    <hint type="sourcelabel" >
-     <x>20</x>
-     <y>20</y>
+    <hint type="sourcelabel">
+     <x>315</x>
+     <y>393</y>
     </hint>
-    <hint type="destinationlabel" >
-     <x>20</x>
-     <y>20</y>
+    <hint type="destinationlabel">
+     <x>315</x>
+     <y>225</y>
     </hint>
    </hints>
   </connection>

--- a/src/mainview.ui
+++ b/src/mainview.ui
@@ -196,7 +196,7 @@
   </widget>
   <action name="ActOpenRepo">
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="document-open-folder" resource="icons.qrc">
      <normaloff>:/icons/resources/folder_open.png</normaloff>:/icons/resources/folder_open.png</iconset>
    </property>
    <property name="text">
@@ -210,6 +210,9 @@
    </property>
   </action>
   <action name="ActExit">
+   <property name="icon">
+    <iconset theme="application-exit"/>
+   </property>
    <property name="text">
     <string>E&amp;xit</string>
    </property>
@@ -221,6 +224,10 @@
    </property>
   </action>
   <action name="ActAbout">
+   <property name="icon">
+    <iconset resource="icons.qrc">
+     <normaloff>:/icons/resources/qgit.png</normaloff>:/icons/resources/qgit.png</iconset>
+   </property>
    <property name="text">
     <string>&amp;About QGit</string>
    </property>
@@ -236,7 +243,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="mail-send" resource="icons.qrc">
      <normaloff>:/icons/resources/mail_send.png</normaloff>:/icons/resources/mail_send.png</iconset>
    </property>
    <property name="text">
@@ -251,7 +258,7 @@
   </action>
   <action name="ActHelp">
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="help-contents" resource="icons.qrc">
      <normaloff>:/icons/resources/help.png</normaloff>:/icons/resources/help.png</iconset>
    </property>
    <property name="text">
@@ -266,7 +273,7 @@
   </action>
   <action name="ActSettings">
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="configure" resource="icons.qrc">
      <normaloff>:/icons/resources/configure.png</normaloff>:/icons/resources/configure.png</iconset>
    </property>
    <property name="text">
@@ -301,6 +308,9 @@
    <property name="enabled">
     <bool>false</bool>
    </property>
+   <property name="icon">
+    <iconset theme="tag"/>
+   </property>
    <property name="text">
     <string>Make &amp;tag...</string>
    </property>
@@ -315,6 +325,9 @@
    </property>
   </action>
   <action name="ActOpenRepoNewWindow">
+   <property name="icon">
+    <iconset theme="window-new"/>
+   </property>
    <property name="text">
     <string>Open in a &amp;new window...</string>
    </property>
@@ -326,6 +339,9 @@
    </property>
   </action>
   <action name="ActClose">
+   <property name="icon">
+    <iconset theme="window-close"/>
+   </property>
    <property name="text">
     <string>&amp;Close</string>
    </property>
@@ -341,7 +357,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="mail-receive" resource="icons.qrc">
      <normaloff>:/icons/resources/mail_get.png</normaloff>:/icons/resources/mail_get.png</iconset>
    </property>
    <property name="text">
@@ -390,7 +406,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="view-refresh" resource="icons.qrc">
      <normaloff>:/icons/resources/reload.png</normaloff>:/icons/resources/reload.png</iconset>
    </property>
    <property name="iconText">
@@ -447,6 +463,9 @@
    <property name="enabled">
     <bool>false</bool>
    </property>
+   <property name="icon">
+    <iconset theme="document-save-as"/>
+   </property>
    <property name="text">
     <string>Save file as...</string>
    </property>
@@ -468,7 +487,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="tools-wizard" resource="icons.qrc">
      <normaloff>:/icons/resources/wizard.png</normaloff>:/icons/resources/wizard.png</iconset>
    </property>
    <property name="text">
@@ -489,7 +508,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="view-list-tree" resource="icons.qrc">
      <normaloff>:/icons/resources/view_tree.png</normaloff>:/icons/resources/view_tree.png</iconset>
    </property>
    <property name="text">
@@ -509,6 +528,9 @@
    <property name="enabled">
     <bool>false</bool>
    </property>
+   <property name="icon">
+    <iconset theme="edit-delete"/>
+   </property>
    <property name="text">
     <string>Delete references...</string>
    </property>
@@ -525,6 +547,9 @@
    </property>
    <property name="enabled">
     <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="folder-sync"/>
    </property>
    <property name="text">
     <string>Check working directory</string>
@@ -594,7 +619,7 @@
   </action>
   <action name="ActSplitView">
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="view-split-top-bottom" resource="icons.qrc">
      <normaloff>:/icons/resources/view_top_bottom.png</normaloff>:/icons/resources/view_top_bottom.png</iconset>
    </property>
    <property name="text">
@@ -611,6 +636,9 @@
    </property>
   </action>
   <action name="ActFind">
+   <property name="icon">
+    <iconset theme="edit-find"/>
+   </property>
    <property name="text">
     <string>Find...</string>
    </property>
@@ -640,7 +668,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="go-next" resource="icons.qrc">
      <normaloff>:/icons/resources/next.png</normaloff>:/icons/resources/next.png</iconset>
    </property>
    <property name="text">
@@ -658,7 +686,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="go-previous" resource="icons.qrc">
      <normaloff>:/icons/resources/previous.png</normaloff>:/icons/resources/previous.png</iconset>
    </property>
    <property name="text">
@@ -673,7 +701,7 @@
   </action>
   <action name="ActCustomActionSetup">
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="bookmarks" resource="icons.qrc">
      <normaloff>:/icons/resources/bookmark.png</normaloff>:/icons/resources/bookmark.png</iconset>
    </property>
    <property name="text">
@@ -686,6 +714,9 @@
   <action name="ActViewFileNewTab">
    <property name="enabled">
     <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="tab-new"/>
    </property>
    <property name="text">
     <string>View file in new tab</string>
@@ -700,6 +731,9 @@
   <action name="ActViewDiffNewTab">
    <property name="enabled">
     <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="tab-new"/>
    </property>
    <property name="text">
     <string>View patch in new tab</string>
@@ -719,7 +753,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="view-filter" resource="icons.qrc">
      <normaloff>:/icons/resources/filter.png</normaloff>:/icons/resources/filter.png</iconset>
    </property>
    <property name="text">
@@ -737,7 +771,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="edit-find" resource="icons.qrc">
      <normaloff>:/icons/resources/find.png</normaloff>:/icons/resources/find.png</iconset>
    </property>
    <property name="text">
@@ -783,7 +817,7 @@
   </action>
   <action name="ActRangeDlg">
    <property name="icon">
-    <iconset resource="icons.qrc">
+    <iconset theme="edit-select" resource="icons.qrc">
      <normaloff>:/icons/resources/range_select.png</normaloff>:/icons/resources/range_select.png</iconset>
    </property>
    <property name="text">
@@ -794,6 +828,9 @@
    </property>
   </action>
   <action name="ActAmend">
+   <property name="icon">
+    <iconset theme="edit-entry"/>
+   </property>
    <property name="text">
     <string>Amend commit...</string>
    </property>

--- a/src/mainview.ui
+++ b/src/mainview.ui
@@ -361,7 +361,7 @@
      <normaloff>:/icons/resources/mail_get.png</normaloff>:/icons/resources/mail_get.png</iconset>
    </property>
    <property name="text">
-    <string>Apply patch...</string>
+    <string>Apply &amp;patch...</string>
    </property>
    <property name="iconText">
     <string>Apply a patch series</string>
@@ -424,7 +424,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>View patch</string>
+    <string>View &amp;patch</string>
    </property>
    <property name="iconText">
     <string>View patch</string>
@@ -467,7 +467,7 @@
     <iconset theme="document-save-as"/>
    </property>
    <property name="text">
-    <string>Save file as...</string>
+    <string>Save file &amp;as...</string>
    </property>
    <property name="iconText">
     <string>Save file as...</string>
@@ -532,7 +532,7 @@
     <iconset theme="edit-delete"/>
    </property>
    <property name="text">
-    <string>Delete references...</string>
+    <string>&amp;Delete references...</string>
    </property>
    <property name="iconText">
     <string>Delete tag</string>
@@ -552,7 +552,7 @@
     <iconset theme="folder-sync"/>
    </property>
    <property name="text">
-    <string>Check working directory</string>
+    <string>&amp;Check working directory</string>
    </property>
    <property name="iconText">
     <string>Check working dir</string>
@@ -563,7 +563,7 @@
   </action>
   <action name="ActMarkDiffToSha">
    <property name="text">
-    <string>Mark for diff</string>
+    <string>&amp;Mark for diff</string>
    </property>
    <property name="iconText">
     <string>Mark for diff</string>
@@ -577,7 +577,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>External diff...</string>
+    <string>E&amp;xternal diff...</string>
    </property>
    <property name="iconText">
     <string>Launch external diff viewer</string>
@@ -591,7 +591,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>External editor...</string>
+    <string>External &amp;editor...</string>
    </property>
    <property name="iconText">
     <string>Launch external editor</string>
@@ -640,7 +640,7 @@
     <iconset theme="edit-find"/>
    </property>
    <property name="text">
-    <string>Find...</string>
+    <string>&amp;Find...</string>
    </property>
    <property name="iconText">
     <string>Find text in current view...</string>
@@ -651,7 +651,7 @@
   </action>
   <action name="ActFindNext">
    <property name="text">
-    <string>Find next</string>
+    <string>Find &amp;next</string>
    </property>
    <property name="iconText">
     <string>Find next</string>
@@ -672,7 +672,7 @@
      <normaloff>:/icons/resources/next.png</normaloff>:/icons/resources/next.png</iconset>
    </property>
    <property name="text">
-    <string>Forward</string>
+    <string>&amp;Forward</string>
    </property>
    <property name="iconText">
     <string>Forward</string>
@@ -690,7 +690,7 @@
      <normaloff>:/icons/resources/previous.png</normaloff>:/icons/resources/previous.png</iconset>
    </property>
    <property name="text">
-    <string>Back</string>
+    <string>&amp;Back</string>
    </property>
    <property name="iconText">
     <string>Back</string>
@@ -705,7 +705,7 @@
      <normaloff>:/icons/resources/bookmark.png</normaloff>:/icons/resources/bookmark.png</iconset>
    </property>
    <property name="text">
-    <string>Setup actions...</string>
+    <string>&amp;Setup actions...</string>
    </property>
    <property name="iconText">
     <string>Setup actions...</string>
@@ -789,7 +789,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show header info</string>
+    <string>Show &amp;header info</string>
    </property>
    <property name="iconText">
     <string>Show header info</string>
@@ -832,7 +832,7 @@
     <iconset theme="edit-entry"/>
    </property>
    <property name="text">
-    <string>Amend commit...</string>
+    <string>&amp;Amend commit...</string>
    </property>
    <property name="toolTip">
     <string>Amend previous commit</string>

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -29,592 +29,567 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QHBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="margin">
-    <number>9</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QVBoxLayout">
-     <property name="spacing">
-      <number>6</number>
+    <widget class="QTabWidget" name="tabDialog">
+     <property name="currentIndex">
+      <number>5</number>
      </property>
-     <property name="margin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QTabWidget" name="tabDialog">
-       <property name="currentIndex">
-        <number>5</number>
+     <widget class="QWidget" name="General">
+      <attribute name="title">
+       <string>&amp;General</string>
+      </attribute>
+      <layout class="QHBoxLayout">
+       <property name="spacing">
+        <number>6</number>
        </property>
-       <widget class="QWidget" name="General">
-        <attribute name="title">
-         <string>&amp;General</string>
-        </attribute>
-        <layout class="QHBoxLayout">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
+        <number>9</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout">
          <property name="spacing">
           <number>6</number>
          </property>
-         <property name="margin">
-          <number>9</number>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
          </property>
          <item>
-          <layout class="QVBoxLayout">
-           <property name="spacing">
-            <number>6</number>
+          <widget class="QFrame" name="frame">
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
            </property>
-           <property name="margin">
-            <number>0</number>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
            </property>
-           <item>
-            <widget class="QFrame" name="frame">
-             <property name="frameShape">
-              <enum>QFrame::StyledPanel</enum>
-             </property>
-             <property name="frameShadow">
-              <enum>QFrame::Raised</enum>
-             </property>
-             <layout class="QHBoxLayout">
+           <layout class="QHBoxLayout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item>
+             <layout class="QVBoxLayout">
               <property name="spacing">
                <number>6</number>
               </property>
-              <property name="margin">
-               <number>9</number>
-              </property>
-              <item>
-               <layout class="QVBoxLayout">
-                <property name="spacing">
-                 <number>6</number>
-                </property>
-                <property name="margin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxRelativeDate">
-                  <property name="toolTip">
-                   <string>Check to see commit author date as relative time from now</string>
-                  </property>
-                  <property name="text">
-                   <string>Relati&amp;ve time in date column</string>
-                  </property>
-                  <property name="shortcut">
-                   <string>Alt+V</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxRangeSelectDialog">
-                  <property name="toolTip">
-                   <string>Check to view range select dialog at repository opening</string>
-                  </property>
-                  <property name="text">
-                   <string>Show range select when opening a repositor&amp;y</string>
-                  </property>
-                  <property name="shortcut">
-                   <string>Alt+Y</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxReopenLastRepo">
-                  <property name="text">
-                   <string>Reopen last repository on startup</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxOpenInEditor">
-                  <property name="text">
-                   <string>Double click opens file in editor</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <spacer>
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>21</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <layout class="QGridLayout">
-             <property name="margin">
-              <number>0</number>
-             </property>
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <item row="1" column="2">
-              <widget class="QPushButton" name="pushButtonExtDiff">
-               <property name="maximumSize">
-                <size>
-                 <width>40</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>Browse directories</string>
-               </property>
-               <property name="text">
-                <string>...</string>
-               </property>
-               <property name="shortcut">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="lineEditTypeWriterFont">
-               <property name="toolTip">
-                <string>Typewriter (fixed width) font used by patch and file viewers</string>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="textLabelTypewriterFont">
-               <property name="text">
-                <string>Fixed width font</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditTypeWriterFont</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="lineEditExternalDiffViewer">
-               <property name="toolTip">
-                <string>Set path of the external diff tool</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="textLabelExternalDiffViewer">
-               <property name="text">
-                <string>&amp;External diff tool</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditExternalDiffViewer</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="QLineEdit" name="lineEditExternalEditor">
-               <property name="toolTip">
-                <string>Set path of the external editor</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="textLabelExternalEditor">
-               <property name="text">
-                <string>&amp;External editor</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditExternalEditor</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="2">
-              <widget class="QPushButton" name="pushButtonExtEditor">
-               <property name="maximumSize">
-                <size>
-                 <width>40</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>Browse directories</string>
-               </property>
-               <property name="text">
-                <string>...</string>
-               </property>
-               <property name="shortcut">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QPushButton" name="pushButtonFont">
-               <property name="maximumSize">
-                <size>
-                 <width>40</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>Choose font</string>
-               </property>
-               <property name="text">
-                <string>...</string>
-               </property>
-               <property name="shortcut">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QLabel" name="labelDiffHint">
-               <property name="text">
-                <string>Use %1 and %2 to denote files to diff.</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="QLabel" name="labelEditorHint">
-               <property name="text">
-                <string>Use %1 to denote files to edit.</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <spacer>
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <layout class="QHBoxLayout">
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <property name="margin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="textLabelCodecs">
-               <property name="toolTip">
-                <string>Select text codec to use. You need to refresh the view (F5) after a codec change</string>
-               </property>
-               <property name="text">
-                <string>Te&amp;xt codec</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>comboBoxCodecs</cstring>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="comboBoxCodecs">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>1</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>Select text codec to use. You need to refresh the view (F5) after a codec change</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="Browse">
-        <attribute name="title">
-         <string>&amp;Browse</string>
-        </attribute>
-        <layout class="QHBoxLayout">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="margin">
-          <number>9</number>
-         </property>
-         <item>
-          <layout class="QVBoxLayout">
-           <property name="spacing">
-            <number>0</number>
-           </property>
-           <property name="margin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QFrame" name="frame_5">
-             <property name="frameShape">
-              <enum>QFrame::StyledPanel</enum>
-             </property>
-             <property name="frameShadow">
-              <enum>QFrame::Raised</enum>
-             </property>
-             <layout class="QHBoxLayout">
-              <property name="spacing">
+              <property name="leftMargin">
                <number>0</number>
               </property>
-              <property name="margin">
-               <number>2</number>
-              </property>
-              <item>
-               <layout class="QVBoxLayout">
-                <property name="spacing">
-                 <number>4</number>
-                </property>
-                <property name="margin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxLogDiffTab">
-                  <property name="toolTip">
-                   <string>Check to see tabbed revision log / diff pane</string>
-                  </property>
-                  <property name="text">
-                   <string>Show tabbed revision msg / diff pane</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxSmartLabels">
-                  <property name="toolTip">
-                   <string>Check to show smart jump labels on revision description pane</string>
-                  </property>
-                  <property name="text">
-                   <string>Show smart labels</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxMsgOnNewSHA">
-                  <property name="toolTip">
-                   <string>Check to see always the revision description in main view when browsing the repo. Patch content will be visible after request.</string>
-                  </property>
-                  <property name="text">
-                   <string>Show always revision message as first </string>
-                  </property>
-                  <property name="shortcut">
-                   <string>Alt+Y</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <spacer>
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>71</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="Patch">
-        <attribute name="title">
-         <string>Patc&amp;h</string>
-        </attribute>
-        <layout class="QHBoxLayout">
-         <item>
-          <layout class="QVBoxLayout">
-           <item>
-            <widget class="QFrame" name="frame_2">
-             <property name="frameShape">
-              <enum>QFrame::StyledPanel</enum>
-             </property>
-             <property name="frameShadow">
-              <enum>QFrame::Raised</enum>
-             </property>
-             <layout class="QHBoxLayout">
-              <property name="spacing">
+              <property name="topMargin">
                <number>0</number>
               </property>
-              <property name="margin">
-               <number>2</number>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
               </property>
               <item>
-               <layout class="QVBoxLayout">
-                <property name="spacing">
-                 <number>4</number>
+               <widget class="QCheckBox" name="checkBoxRelativeDate">
+                <property name="toolTip">
+                 <string>Check to see commit author date as relative time from now</string>
                 </property>
-                <property name="margin">
-                 <number>0</number>
+                <property name="text">
+                 <string>Relati&amp;ve time in date column</string>
                 </property>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxNumbers">
-                  <property name="toolTip">
-                   <string>Check to see patch numbers on patch series header</string>
-                  </property>
-                  <property name="text">
-                   <string>Num&amp;bered patches</string>
-                  </property>
-                  <property name="shortcut">
-                   <string>Alt+B</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxSign">
-                  <property name="toolTip">
-                   <string>Check to add a 'Signed-off-by:' line if not already existent</string>
-                  </property>
-                  <property name="text">
-                   <string>&amp;Sign off patch</string>
-                  </property>
-                  <property name="shortcut">
-                   <string>Alt+S</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
+                <property name="shortcut">
+                 <string>Alt+V</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxRangeSelectDialog">
+                <property name="toolTip">
+                 <string>Check to view range select dialog at repository opening</string>
+                </property>
+                <property name="text">
+                 <string>Show range select when opening a repositor&amp;y</string>
+                </property>
+                <property name="shortcut">
+                 <string>Alt+Y</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxReopenLastRepo">
+                <property name="text">
+                 <string>Reopen last repository on startup</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxOpenInEditor">
+                <property name="text">
+                 <string>Double click opens file in editor</string>
+                </property>
+               </widget>
               </item>
              </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>21</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QGridLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item row="1" column="2">
+            <widget class="QPushButton" name="pushButtonExtDiff">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Browse directories</string>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="shortcut">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="lineEditTypeWriterFont">
+             <property name="toolTip">
+              <string>Typewriter (fixed width) font used by patch and file viewers</string>
+             </property>
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="textLabelTypewriterFont">
+             <property name="text">
+              <string>&amp;Fixed width font</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditTypeWriterFont</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="lineEditExternalDiffViewer">
+             <property name="toolTip">
+              <string>Set path of the external diff tool</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="textLabelExternalDiffViewer">
+             <property name="text">
+              <string>&amp;External diff tool</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditExternalDiffViewer</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLineEdit" name="lineEditExternalEditor">
+             <property name="toolTip">
+              <string>Set path of the external editor</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="textLabelExternalEditor">
+             <property name="text">
+              <string>&amp;External editor</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditExternalEditor</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QPushButton" name="pushButtonExtEditor">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Browse directories</string>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="shortcut">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QPushButton" name="pushButtonFont">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Choose font</string>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="shortcut">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="labelDiffHint">
+             <property name="text">
+              <string>Use %1 and %2 to denote files to diff.</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QLabel" name="labelEditorHint">
+             <property name="text">
+              <string>Use %1 to denote files to edit.</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QHBoxLayout">
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="textLabelCodecs">
+             <property name="toolTip">
+              <string>Select text codec to use. You need to refresh the view (F5) after a codec change</string>
+             </property>
+             <property name="text">
+              <string>Te&amp;xt codec</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>comboBoxCodecs</cstring>
+             </property>
             </widget>
            </item>
            <item>
-            <spacer>
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
+            <widget class="QComboBox" name="comboBoxCodecs">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>1</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>399</width>
-               <height>91</height>
-              </size>
+             <property name="toolTip">
+              <string>Select text codec to use. You need to refresh the view (F5) after a codec change</string>
              </property>
-            </spacer>
-           </item>
-           <item>
-            <layout class="QGridLayout">
-             <item row="0" column="0">
-              <widget class="QLabel" name="textLabelApplyPatchExtraOptions">
-               <property name="text">
-                <string>&amp;Apply patch extra options</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditApplyPatchExtraOptions</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="lineEditApplyPatchExtraOptions">
-               <property name="toolTip">
-                <string>Extra options to pass to 'git am'</string>
-               </property>
-               <property name="maxLength">
-                <number>32767</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="textLabelFormatPatchExtraOptions">
-               <property name="text">
-                <string>&amp;Format patch extra options</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditFormatPatchExtraOptions</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="lineEditFormatPatchExtraOptions">
-               <property name="toolTip">
-                <string>Extra options to pass to 'git format-patch'</string>
-               </property>
-               <property name="maxLength">
-                <number>32767</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            </widget>
            </item>
           </layout>
          </item>
         </layout>
-       </widget>
-       <widget class="QWidget" name="WorkingDir">
-        <attribute name="title">
-         <string>&amp;Working directory</string>
-        </attribute>
-        <layout class="QHBoxLayout">
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="Browse">
+      <attribute name="title">
+       <string>&amp;Browse</string>
+      </attribute>
+      <layout class="QHBoxLayout">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
+        <number>9</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout">
          <property name="spacing">
-          <number>6</number>
+          <number>0</number>
          </property>
-         <property name="margin">
-          <number>9</number>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
          </property>
          <item>
-          <layout class="QVBoxLayout">
-           <property name="spacing">
-            <number>0</number>
+          <widget class="QFrame" name="frame_5">
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
            </property>
-           <property name="margin">
-            <number>0</number>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
            </property>
-           <item>
-            <widget class="QFrame" name="frame_3">
-             <property name="frameShape">
-              <enum>QFrame::StyledPanel</enum>
-             </property>
-             <property name="frameShadow">
-              <enum>QFrame::Raised</enum>
-             </property>
-             <layout class="QHBoxLayout">
+           <layout class="QHBoxLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>2</number>
+            </property>
+            <property name="topMargin">
+             <number>2</number>
+            </property>
+            <property name="rightMargin">
+             <number>2</number>
+            </property>
+            <property name="bottomMargin">
+             <number>2</number>
+            </property>
+            <item>
+             <layout class="QVBoxLayout">
               <property name="spacing">
                <number>4</number>
               </property>
-              <property name="margin">
-               <number>5</number>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
               </property>
               <item>
-               <widget class="QCheckBox" name="checkBoxDiffCache">
+               <widget class="QCheckBox" name="checkBoxLogDiffTab">
                 <property name="toolTip">
-                 <string>Check to see git status. You need this to commit changes</string>
+                 <string>Check to see tabbed revision log / diff pane</string>
                 </property>
                 <property name="text">
-                 <string>Diff again&amp;st working directory</string>
+                 <string>Show tabbed revision msg / diff pane</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxSmartLabels">
+                <property name="toolTip">
+                 <string>Check to show smart jump labels on revision description pane</string>
+                </property>
+                <property name="text">
+                 <string>Show smart labels</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxMsgOnNewSHA">
+                <property name="toolTip">
+                 <string>Check to see always the revision description in main view when browsing the repo. Patch content will be visible after request.</string>
+                </property>
+                <property name="text">
+                 <string>Show always revision message as first </string>
+                </property>
+                <property name="shortcut">
+                 <string>Alt+Y</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>71</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="Patch">
+      <attribute name="title">
+       <string>Patc&amp;h</string>
+      </attribute>
+      <layout class="QHBoxLayout">
+       <item>
+        <layout class="QVBoxLayout">
+         <item>
+          <widget class="QFrame" name="frame_2">
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <layout class="QHBoxLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>2</number>
+            </property>
+            <property name="topMargin">
+             <number>2</number>
+            </property>
+            <property name="rightMargin">
+             <number>2</number>
+            </property>
+            <property name="bottomMargin">
+             <number>2</number>
+            </property>
+            <item>
+             <layout class="QVBoxLayout">
+              <property name="spacing">
+               <number>4</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QCheckBox" name="checkBoxNumbers">
+                <property name="toolTip">
+                 <string>Check to see patch numbers on patch series header</string>
+                </property>
+                <property name="text">
+                 <string>Num&amp;bered patches</string>
+                </property>
+                <property name="shortcut">
+                 <string>Alt+B</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxSign">
+                <property name="toolTip">
+                 <string>Check to add a 'Signed-off-by:' line if not already existent</string>
+                </property>
+                <property name="text">
+                 <string>&amp;Sign off patch</string>
                 </property>
                 <property name="shortcut">
                  <string>Alt+S</string>
@@ -622,401 +597,576 @@
                </widget>
               </item>
              </layout>
-            </widget>
-           </item>
-           <item>
-            <spacer>
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <layout class="QGridLayout">
-             <property name="margin">
-              <number>0</number>
-             </property>
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="lineEditExcludePerDir">
-               <property name="toolTip">
-                <string>Exclude patterns file that apply only to the
-	directory and its subdirectories</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="lineEditExcludeFile">
-               <property name="toolTip">
-                <string>Exclude patterns are read from this file one per line</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="textLabelExcludePerDir">
-               <property name="text">
-                <string>E&amp;xclude per dir</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditExcludePerDir</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="textLabelExcludeFile">
-               <property name="text">
-                <string>&amp;Exclude file path</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditExcludeFile</cstring>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
+            </item>
+           </layout>
+          </widget>
          </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="Commit">
-        <attribute name="title">
-         <string>&amp;Commit</string>
-        </attribute>
-        <layout class="QHBoxLayout">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="margin">
-          <number>9</number>
-         </property>
          <item>
-          <layout class="QVBoxLayout">
-           <property name="spacing">
-            <number>0</number>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
            </property>
-           <property name="margin">
-            <number>0</number>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>399</width>
+             <height>91</height>
+            </size>
            </property>
-           <item>
-            <widget class="QFrame" name="frame_4">
-             <property name="frameShape">
-              <enum>QFrame::StyledPanel</enum>
-             </property>
-             <property name="frameShadow">
-              <enum>QFrame::Raised</enum>
-             </property>
-             <layout class="QHBoxLayout">
-              <property name="spacing">
-               <number>0</number>
-              </property>
-              <property name="margin">
-               <number>2</number>
-              </property>
-              <item>
-               <layout class="QVBoxLayout">
-                <property name="spacing">
-                 <number>4</number>
-                </property>
-                <property name="margin">
-                 <number>3</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxCommitSign">
-                  <property name="toolTip">
-                   <string>Check to add -s option to git commit-script</string>
-                  </property>
-                  <property name="text">
-                   <string>&amp;Sign off commit</string>
-                  </property>
-                  <property name="shortcut">
-                   <string>Alt+S</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxCommitVerify">
-                  <property name="toolTip">
-                   <string>Check to add -v option to git commit-script</string>
-                  </property>
-                  <property name="text">
-                   <string>&amp;Verify commit</string>
-                  </property>
-                  <property name="shortcut">
-                   <string>Alt+V</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="checkBoxCommitUseDefMsg">
-                  <property name="text">
-                   <string>Use default commit message</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <spacer>
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>21</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <layout class="QGridLayout">
-             <property name="margin">
-              <number>0</number>
-             </property>
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <item row="0" column="2">
-              <widget class="QLabel" name="textLabelComboUsr">
-               <property name="text">
-                <string>Defined in:                           </string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="textLabelAuthor">
-               <property name="text">
-                <string>Author</string>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditAuthor</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="2">
-              <widget class="QComboBox" name="comboBoxUserSrc"/>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="lineEditAuthor">
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="lineEditMail">
-               <property name="readOnly">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="textLabelAuthor_2">
-               <property name="text">
-                <string>E-mail</string>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditMail</cstring>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <spacer>
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>21</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <layout class="QGridLayout">
-             <property name="margin">
-              <number>0</number>
-             </property>
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="textLabelTemplate">
-               <property name="text">
-                <string>Ms&amp;g template</string>
-               </property>
-               <property name="textFormat">
-                <enum>Qt::PlainText</enum>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditAuthor</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="textLabelDiffTreeArgs_2">
-               <property name="text">
-                <string>&amp;Extra options</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>lineEditCommitExtraOptions</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="lineEditTemplate">
-               <property name="toolTip">
-                <string>Commit message template file</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="lineEditCommitExtraOptions">
-               <property name="toolTip">
-                <string>Extra options to pass to git commit-script</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
+          </spacer>
          </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="GitConfig">
-        <attribute name="title">
-         <string>Gi&amp;t config</string>
-        </attribute>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <item>
-              <spacer name="horizontalSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QLabel" name="textLabelGitConfigSource">
-               <property name="text">
-                <string>Git options source:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="comboBoxGitConfigSource">
-               <item>
-                <property name="text">
-                 <string>Local</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>Global</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="QTreeWidget" name="treeWidgetGitConfig">
-             <property name="columnCount">
-              <number>2</number>
+          <layout class="QGridLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="textLabelApplyPatchExtraOptions">
+             <property name="text">
+              <string>&amp;Apply patch extra options</string>
              </property>
-             <column>
-              <property name="text">
-               <string notr="true">Parameter</string>
-              </property>
-             </column>
-             <column>
-              <property name="text">
-               <string>Value</string>
-              </property>
-             </column>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditApplyPatchExtraOptions</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="lineEditApplyPatchExtraOptions">
+             <property name="toolTip">
+              <string>Extra options to pass to 'git am'</string>
+             </property>
+             <property name="maxLength">
+              <number>32767</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="textLabelFormatPatchExtraOptions">
+             <property name="text">
+              <string>&amp;Format patch extra options</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditFormatPatchExtraOptions</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="lineEditFormatPatchExtraOptions">
+             <property name="toolTip">
+              <string>Extra options to pass to 'git format-patch'</string>
+             </property>
+             <property name="maxLength">
+              <number>32767</number>
+             </property>
             </widget>
            </item>
           </layout>
          </item>
         </layout>
-       </widget>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <property name="margin">
-        <number>0</number>
-       </property>
-       <item>
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>181</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="buttonOk">
-         <property name="text">
-          <string>O&amp;K</string>
-         </property>
-         <property name="shortcut">
-          <string>Alt+K</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-         <property name="default">
-          <bool>false</bool>
-         </property>
-        </widget>
        </item>
       </layout>
-     </item>
-    </layout>
+     </widget>
+     <widget class="QWidget" name="WorkingDir">
+      <attribute name="title">
+       <string>&amp;Working directory</string>
+      </attribute>
+      <layout class="QHBoxLayout">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
+        <number>9</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QFrame" name="frame_3">
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <layout class="QHBoxLayout">
+            <property name="spacing">
+             <number>4</number>
+            </property>
+            <property name="leftMargin">
+             <number>5</number>
+            </property>
+            <property name="topMargin">
+             <number>5</number>
+            </property>
+            <property name="rightMargin">
+             <number>5</number>
+            </property>
+            <property name="bottomMargin">
+             <number>5</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="checkBoxDiffCache">
+              <property name="toolTip">
+               <string>Check to see git status. You need this to commit changes</string>
+              </property>
+              <property name="text">
+               <string>Diff again&amp;st working directory</string>
+              </property>
+              <property name="shortcut">
+               <string>Alt+S</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QGridLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="lineEditExcludePerDir">
+             <property name="toolTip">
+              <string>Exclude patterns file that apply only to the
+	directory and its subdirectories</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="lineEditExcludeFile">
+             <property name="toolTip">
+              <string>Exclude patterns are read from this file one per line</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="textLabelExcludePerDir">
+             <property name="text">
+              <string>E&amp;xclude per dir</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditExcludePerDir</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="textLabelExcludeFile">
+             <property name="text">
+              <string>&amp;Exclude file path</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditExcludeFile</cstring>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="Commit">
+      <attribute name="title">
+       <string>&amp;Commit</string>
+      </attribute>
+      <layout class="QHBoxLayout">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
+        <number>9</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QFrame" name="frame_4">
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <layout class="QHBoxLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>2</number>
+            </property>
+            <property name="topMargin">
+             <number>2</number>
+            </property>
+            <property name="rightMargin">
+             <number>2</number>
+            </property>
+            <property name="bottomMargin">
+             <number>2</number>
+            </property>
+            <item>
+             <layout class="QVBoxLayout">
+              <property name="spacing">
+               <number>4</number>
+              </property>
+              <property name="leftMargin">
+               <number>3</number>
+              </property>
+              <property name="topMargin">
+               <number>3</number>
+              </property>
+              <property name="rightMargin">
+               <number>3</number>
+              </property>
+              <property name="bottomMargin">
+               <number>3</number>
+              </property>
+              <item>
+               <widget class="QCheckBox" name="checkBoxCommitSign">
+                <property name="toolTip">
+                 <string>Check to add -s option to git commit-script</string>
+                </property>
+                <property name="text">
+                 <string>&amp;Sign off commit</string>
+                </property>
+                <property name="shortcut">
+                 <string>Alt+S</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxCommitVerify">
+                <property name="toolTip">
+                 <string>Check to add -v option to git commit-script</string>
+                </property>
+                <property name="text">
+                 <string>&amp;Verify commit</string>
+                </property>
+                <property name="shortcut">
+                 <string>Alt+V</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxCommitUseDefMsg">
+                <property name="text">
+                 <string>Use default commit message</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>21</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QGridLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item row="0" column="2">
+            <widget class="QLabel" name="textLabelComboUsr">
+             <property name="text">
+              <string>Defined in:                           </string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="textLabelAuthor">
+             <property name="text">
+              <string>Author</string>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditAuthor</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QComboBox" name="comboBoxUserSrc"/>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="lineEditAuthor">
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="lineEditMail">
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="textLabelAuthor_2">
+             <property name="text">
+              <string>E-mail</string>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditMail</cstring>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>21</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QGridLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="textLabelTemplate">
+             <property name="text">
+              <string>Ms&amp;g template</string>
+             </property>
+             <property name="textFormat">
+              <enum>Qt::PlainText</enum>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditAuthor</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="textLabelDiffTreeArgs_2">
+             <property name="text">
+              <string>&amp;Extra options</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditCommitExtraOptions</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="lineEditTemplate">
+             <property name="toolTip">
+              <string>Commit message template file</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="lineEditCommitExtraOptions">
+             <property name="toolTip">
+              <string>Extra options to pass to git commit-script</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="GitConfig">
+      <attribute name="title">
+       <string>Gi&amp;t config</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="textLabelGitConfigSource">
+             <property name="text">
+              <string>Git options source:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="comboBoxGitConfigSource">
+             <item>
+              <property name="text">
+               <string>Local</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Global</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QTreeWidget" name="treeWidgetGitConfig">
+           <property name="columnCount">
+            <number>2</number>
+           </property>
+           <column>
+            <property name="text">
+             <string notr="true">Parameter</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Value</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -1025,22 +1175,6 @@
   <include location="icons.qrc"/>
  </resources>
  <connections>
-  <connection>
-   <sender>buttonOk</sender>
-   <signal>clicked()</signal>
-   <receiver>settingsBase</receiver>
-   <slot>close()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>501</x>
-     <y>365</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>checkBoxNumbers</sender>
    <signal>toggled(bool)</signal>
@@ -1486,6 +1620,22 @@
     <hint type="destinationlabel">
      <x>147</x>
      <y>359</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>settingsBase</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>451</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>256</x>
+     <y>236</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Modify UI's to use icons from the system icon theme. (Note: this doesn't remove the resource icons; AFAIK/AFAICT, those will still be used if a theme icon is unavailable.) Also, use QButtonBox where appropriate (which automatically uses appropriate theme icons), and remove some superfluous layouts.

Fixes #13.