### PR TITLE
navigation improvements

### DIFF
--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -1275,6 +1275,7 @@ int ListViewProxy::setFilter(bool isOn, bool h, SCRef fl, int cn, ShaSet* s) {
 
 	ListView* lv = static_cast<ListView*>(parent());
 	FileHistory* fh = d->model();
+	SCRef cur = lv->sha(lv->currentIndex().row());
 
 	if (!isOn && sourceModel()){
 		lv->setModel(fh);
@@ -1284,5 +1285,6 @@ int ListViewProxy::setFilter(bool isOn, bool h, SCRef fl, int cn, ShaSet* s) {
 		setSourceModel(fh); // trigger a rows scanning
 		lv->setModel(this);
 	}
+	lv->setCurrentIndex(lv->model()->index(lv->row(cur), 0));
 	return (sourceModel() ? rowCount() : 0);
 }

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -140,6 +140,18 @@ void ListView::scrollToNextHighlighted(int direction) {
 	setCurrentIndex(idx);
 }
 
+void ListView::scrollToNext(int direction) {
+	// Depending on the value of direction, scroll to:
+	// -1 = the next child in history
+	//  1 = the previous parent in history
+	SCRef s = sha(currentIndex().row());
+	const Rev* r = git->revLookup(s);
+	if (!r) return;
+	const QStringList& next = direction < 0 ? git->getChildren(s) : r->parents();
+	if (next.size() >= 1)
+		setCurrentIndex(model()->index(row(next.first()), 0));
+}
+
 void ListView::scrollToCurrent(ScrollHint hint) {
 
 	if (currentIndex().isValid())

--- a/src/listview.h
+++ b/src/listview.h
@@ -29,6 +29,7 @@ public:
 	void showIdValues();
 	void scrollToCurrent(ScrollHint hint = EnsureVisible);
 	void scrollToNextHighlighted(int direction);
+	void scrollToNext(int direction);
 	void getSelectedItems(QStringList& selectedItems);
 	bool update();
 	void addNewRevs(const QVector<QString>& shaVec);

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -1174,6 +1174,8 @@ void MainImpl::goMatch(int delta) {
 
 	if (ActSearchAndHighlight->isChecked())
 		rv->tab()->listViewLog->scrollToNextHighlighted(delta);
+	else
+		rv->tab()->listViewLog->scrollToNext(delta);
 }
 
 QTextEdit* MainImpl::getCurrentTextEdit() {


### PR DESCRIPTION
These two commits aim to improve navigation in `ListView`.
1. After filtering, the current index should be kept
2. Using SHIFT + UP/DOWN it's now possible to navigate between commits along branches (if filter-highlighting is not active)