### PR TITLE
Properly handle GPG signatures in log, fix git version comparisons.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -66,7 +66,7 @@ uint qHash(const ShaString&); // optimized custom hash for sha strings
 namespace QGit {
 
 	// minimum git version required
-	extern const QString GIT_VERSION;
+	extern const QString GIT_VERSION_REQUIRED;
 
 	// tab pages
 	enum TabType {

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -73,12 +73,12 @@ void Git::checkEnvironment() {
 	if (run("git --version", &version)) {
 
 		version = version.section(' ', -1, -1).section('.', 0, 2);
-		if (version < GIT_VERSION) {
+		if (version < GIT_VERSION_REQUIRED) {
 
 			// simply send information, the 'not compatible version'
 			// policy should be implemented upstream
 			const QString cmd("Current git version is " + version +
-			      " but is required " + GIT_VERSION + " or better");
+			      " but is required " + GIT_VERSION_REQUIRED + " or better");
 
 			const QString errorDesc("Your installed git is too old."
 			      "\nPlease upgrade to avoid possible misbehaviours.");

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -2167,6 +2167,9 @@ bool Git::startRevList(SCList args, FileHistory* fh) {
         } else
                 {} // initCmd << QString("--early-output"); currently disabled
 
+        if (gitVersion >= "2.10.0")
+                initCmd << "--no-show-signature";
+
         return startParseProc(initCmd + args, fh, QString());
 }
 
@@ -2186,6 +2189,10 @@ bool Git::startUnappliedList() {
                     "--pretty=format:" GIT_LOG_FORMAT "%b ^HEAD");
 
         QStringList sl(cmd.split(' '));
+
+        if (gitVersion >= "2.10.0")
+                sl << "--no-show-signature";
+
         sl << unAppliedShaList;
         return startParseProc(sl, revData, QString());
 }

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -86,6 +86,7 @@ void Git::checkEnvironment() {
 			MainExecErrorEvent* e = new MainExecErrorEvent(cmd, errorDesc);
 			QApplication::postEvent(parent(), e);
 		}
+		gitVersion = version;
 	} else {
 		dbs("Cannot find git files");
 		return;

--- a/src/git.h
+++ b/src/git.h
@@ -267,6 +267,7 @@ private:
 	QString curBranchName;
 	int filesLoadingStartOfs;
 	bool cacheNeedsUpdate;
+	QString gitVersion;
 	bool errorReportingEnabled;
 	bool isMergeHead;
 	bool isStGIT;

--- a/src/git.h
+++ b/src/git.h
@@ -56,6 +56,7 @@ public:
 	typedef QList<TreeEntry> TreeInfo;
 
 	void setDefaultModel(FileHistory* fh) { revData = fh; }
+	static int gitVersionCompare(QString lhs, QString rhs);
 	void checkEnvironment();
 	void userInfo(SList info);
 	const QStringList getGitConfigList(bool global);

--- a/src/namespace_def.cpp
+++ b/src/namespace_def.cpp
@@ -124,7 +124,7 @@ const ShaString QGit::toPersistentSha(const QString& sha, QVector<QByteArray>& v
 }
 
 // minimum git version required
-const QString QGit::GIT_VERSION = "1.5.5";
+const QString QGit::GIT_VERSION_REQUIRED = "1.5.5";
 
 // colors
 const QColor QGit::BROWN        = QColor(150, 75, 0);


### PR DESCRIPTION
This fixes #66 and incorrect git version comparisons in src/git.cpp.