### PR TITLE
MainBase: Change "Checkout" shortcut to Ctrl+Shift+C

### DIFF
--- a/src/mainview.ui
+++ b/src/mainview.ui
@@ -866,7 +866,7 @@
     <string>Checkout selected revision</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+C</string>
+    <string>Ctrl+Shift+C</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This adds `Shift` to the "Checkout" keyboard shortcut so `Ctrl+C` copies to the clipboard as expected. Fixes #34