### PR TITLE
Allow opening a file from the command line (RFE #79)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -101,6 +101,10 @@ You can select top and bottom rev tags from the list or paste a
 specific revision. Values are passed to 'git log' to narrow
 data loading to chosen revisions.
 
+As a special command-line argument, '--view-file foo' or '--view-file=foo' is
+not passed to 'git log', but opens the file 'foo' in the QGit file viewer,
+showing the history and the annotated ('blame') view for the file.
+
 
 Main view
 ---------

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -1661,7 +1661,19 @@ const QStringList Git::getArgs(bool* quit, bool repoChanged) {
         arglist.removeFirst();
 
         if (startup) {
+                bool ignoreNext = false;
                 foreach (QString arg, arglist) {
+                        // ignore --view-file=* and --view-file * QGit arguments
+                        if (ignoreNext) {
+                                ignoreNext = false;
+                                continue;
+                        } else if (arg.startsWith("--view-file="))
+                                continue;
+                        else if (arg == "--view-file") {
+                                ignoreNext = true;
+                                continue;
+                        }
+
                         // in arguments with spaces double quotes
                         // are stripped by Qt, so re-add them
                         if (arg.contains(' '))

--- a/src/mainimpl.h
+++ b/src/mainimpl.h
@@ -183,6 +183,7 @@ private:
 	// we are sure is correct.
 	QString curDir;
 	QString startUpDir;
+	QString startUpFile;
 	QString textToFind;
 	QRegExp shortLogRE;
 	QRegExp longLogRE;


### PR DESCRIPTION
Add the `--view-file` command line argument. Both `--view-file=foo` and
`--view-file foo` are accepted. (The latter is what `git-cola` needs.)