### PR TITLE
QPixmap already takes the device's pixel ratio into account

### DIFF
--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -1191,10 +1191,6 @@ void ListViewDelegate::addTextPixmap(QPixmap** pp, SCRef txt, const QStyleOption
 			 (text_height) * static_cast<int>(dpr()));
 
 	QPixmap* newPm = new QPixmap(pixmapSize);
-#if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
-    newPm->setDevicePixelRatio(dpr());
-#endif
-
 	QPainter p;
 	p.begin(newPm);
 


### PR DESCRIPTION
# Platform information

> Operating System: Kubuntu 19.10
> KDE Plasma Version: 5.17.5
> KDE Frameworks Version: 5.66.0
> Qt Version: 5.12.4
> Kernel Version: 5.3.0-29-generic
> OS Type: 64-bit
> Processors: 4 × Intel® Core™ i7-7500U CPU @ 2.70GHz
> Memory: 15.5 GiB of RAM

It's a Dell XPS laptop running the stock Kubuntu with the KDE backports. My laptop screen is 3200x1800 which I scale 1.5x in the System Settings.

# Problem

qgit shows a gap between the tag / branch labels and the log message: ![Screenshot_20200206_235056](https://user-images.githubusercontent.com/623458/73988856-dbef1b80-493b-11ea-8610-7ad179d3659b.png)

The gap looked to about half the size of the label, so I got the idea it was linked to the scaling factor

# Proposed solution

I think because `pixmapSize` above already takes the device pixel ratio into account we don't need to set it again on `newPm`. This seems to work on my laptop:
![Screenshot_20200206_235302](https://user-images.githubusercontent.com/623458/73988860-dc87b200-493b-11ea-98af-8c0f6d2d5049.png)
but ...

# Next problem

If you look closely you will see that the labels look less sharp with my "fix". If you look at the green box for _master_, it's about 80px wide in my screenshots, and it feels like the text has now been generated at a smaller resolution, and probably up-scaled 1.5x.

What do you think ?
I'll try to play with the various size variables if I can find another fix.

Regards,
Matthieu