### PR TITLE
Support for fractional device pixel ratio

### DIFF
--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -1065,7 +1065,7 @@ void ListViewDelegate::paintLog(QPainter* p, const QStyleOptionViewItem& opt,
 	QStyleOptionViewItem newOpt(opt); // we need a copy
 	if (pm) {
 		p->drawPixmap(newOpt.rect.x(), newOpt.rect.y() + 1, *pm); // +1 means leave a pixel spacing above the pixmap
-		newOpt.rect.adjust(pm->width() / static_cast<int>(dpr()), 0, 0, 0);
+		newOpt.rect.adjust(int(pm->width() / dpr()), 0, 0, 0);
 		delete pm;
 	}
 	if (isHighlighted)
@@ -1179,7 +1179,7 @@ void ListViewDelegate::addTextPixmap(QPixmap** pp, SCRef txt, const QStyleOption
 	QPixmap* pm = *pp;
 
 	const unsigned int mark_spacing = 2; // Space between markers in pixels
-	unsigned int offset = pm->isNull() ? 0 : (pm->width() / static_cast<uint>(dpr())) + mark_spacing; // Marker's offset in the base pixmap
+	unsigned int offset = pm->isNull() ? 0 : (unsigned int) (pm->width() / dpr()) + mark_spacing; // Marker's offset in the base pixmap
 
 	QFontMetrics fm(opt.font);
 	const unsigned int text_spacing = 4;
@@ -1187,8 +1187,8 @@ void ListViewDelegate::addTextPixmap(QPixmap** pp, SCRef txt, const QStyleOption
 	unsigned int text_height = fm.height();
 
 	// Define size of the new Pixmap
-	QSize pixmapSize((offset + text_width) * static_cast<int>(dpr()),
-			 (text_height) * static_cast<int>(dpr()));
+	QSize pixmapSize(int((offset + text_width) * dpr()),
+			 int(text_height * dpr()));
 
 	QPixmap* newPm = new QPixmap(pixmapSize);
 #if QT_VERSION >= QT_VERSION_CHECK(5,6,0)


### PR DESCRIPTION
# Platform information

> Operating System: Kubuntu 19.10
> KDE Plasma Version: 5.17.5
> KDE Frameworks Version: 5.66.0
> Qt Version: 5.12.4
> Kernel Version: 5.3.0-29-generic
> OS Type: 64-bit
> Processors: 4 × Intel® Core™ i7-7500U CPU @ 2.70GHz
> Memory: 15.5 GiB of RAM

It's a Dell XPS laptop running the stock Kubuntu with the KDE backports. My laptop screen is 3200x1800 which I scale 1.5x in the System Settings.

# Problem

Follow-up of #86, but I now understand what is going on :)

On the master branch, the tag / branch labels are truncated: ![Screenshot_20200207_002728](https://user-images.githubusercontent.com/623458/73990394-e2cc5d00-4940-11ea-9429-35e04fc8d8e4.png)

# Solution

This is due to the fact `dpr` is systematically cast into an integer prior to the multiplication / division. This essentially rounds down / up fractional pixel ratios. On my device, the scaling factor is set to 1.5, so `dpr` was rounded up to 2.

I have moved the casts outside of the multiplications / divisions and it works: ![Screenshot_20200207_014259](https://user-images.githubusercontent.com/623458/73993790-33e14e80-494b-11ea-869c-a8a4071df33e.png)
(unlike my attempt in #86 the labels are drawn at the full resolution this time)

The problem was essentially caused by this commit: 65b369a94efc3d4a055a1635651426c9dbc1f86b. Do you remember what sort of warnings you had ? I tried compiling in _debug_ mode but I don't see any warnings on those lines.

Regards,
Matthieu