### PR TITLE
Ignore mac folder prefs, fix tab focus on find/'end of document' messagebox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ qgit.pro.*
 qgit.qbs.*
 src/release
 .qmake.stash
+.DS_Store

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -282,7 +282,7 @@ void MainImpl::ActExternalDiff_activated() {
 	if (!QGit::startProcess(externalDiff, args)) {
 		QString text("Cannot start external viewer: ");
 		text.append(args[0]);
-		QMessageBox::warning(this, "Error - QGit", text);
+        QMessageBox::warning(this, "Error - QGit", text);
 		delete externalDiff;
 	}
 }
@@ -2109,9 +2109,21 @@ void MainImpl::ActFindNext_activated() {
 			             textToFind + "\" not found!", QMessageBox::Ok, 0);
 			return;
 		}
-		if (QMessageBox::question(this, "Find text - QGit", "End of document "
-		    "reached\n\nDo you want to continue from beginning?", QMessageBox::Yes,
-		    QMessageBox::No | QMessageBox::Escape) == QMessageBox::No)
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("Find text - QGit");
+        msgBox.setIcon(QMessageBox::Question);
+        msgBox.setText(tr("End of document reached."));
+        msgBox.setInformativeText(tr("Do you want to continue from beginning?\n"));
+        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        msgBox.setDefaultButton(QMessageBox::No);
+        msgBox.setBaseSize(QSize(400, 160));
+        QList<QAbstractButton *> bList = msgBox.buttons();
+        for (int i=0; i<bList.count(); i++)
+        {
+            bList.at(i)->setFocusPolicy(Qt::StrongFocus);
+        }
+        int ret = msgBox.exec();
+        if (ret == QMessageBox::No)
 			return;
 
 		endOfDocument = true;


### PR DESCRIPTION
When using option+f to find content in a diff, when it prompts to search from the beginning of the file, I am unable to:

1. press the space key to act on the hightlighted button
2. use the tab key to move between buttons
3. use the arrow keys to move between buttons

I also noticed that you use the bold heading text for the entire message, which, I'm ambivalent about. 

I've created a branch that fixes the focus for me. It's likely a mac os x issue, an older one at that. I'll attach a screenshot momentarily of what it looks like.

Signed-off-by: Daniel Kettle <initial.dann@gmail.com>