### PR TITLE
don't rely on STDERR for determining whether command failed

### DIFF
--- a/qgit.geany
+++ b/qgit.geany
@@ -1,0 +1,44 @@
+[editor]
+line_wrapping=false
+auto_continue_multiline=false
+line_break_column=80
+
+[file_prefs]
+final_new_line=false
+ensure_convert_new_lines=false
+strip_trailing_spaces=true
+replace_tabs=false
+
+[indentation]
+indent_width=2
+indent_type=1
+indent_hard_tab_width=4
+detect_indent=true
+detect_indent_width=true
+indent_mode=3
+
+[project]
+name=dropbear
+base_path=src/
+description=QT Git Browser
+file_patterns=*.c;*.cpp;*.h;*.hpp;
+
+[long line marker]
+long_line_behaviour=1
+long_line_column=80
+
+[prjorg]
+source_patterns=*.c;*.C;*.cpp;*.cxx;*.c++;*.cc;*.m;
+header_patterns=*.h;*.H;*.hpp;*.hxx;*.h++;*.hh;
+ignored_dirs_patterns=.*;CVS;
+ignored_file_patterns=*.o;*.obj;*.a;*.lib;*.so;*.dll;*.lo;*.la;*.class;*.jar;*.pyc;*.mo;*.gmo;
+generate_tag_prefs=1
+external_dirs=
+
+[build-menu]
+NF_00_LB=_Make
+NF_00_CM=make
+NF_00_WD=
+NF_01_LB=Make Custom _Target...
+NF_01_CM=make 
+NF_01_WD=

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -993,7 +993,7 @@ bool MainImpl::event(QEvent* e) {
 		EM_PROCESS_EVENTS;
 		MainExecErrorEvent* me = (MainExecErrorEvent*)e;
 		QString text("An error occurred while executing command:\n\n");
-		text.append(me->command() + "\n\nGit says: \n\n" + me->report());
+		text.append(me->command() + "\n\n" + me->report());
 		QMessageBox::warning(this, "Error - QGit", text);
 		QApplication::restoreOverrideCursor(); }
 		break;

--- a/src/myprocess.cpp
+++ b/src/myprocess.cpp
@@ -165,7 +165,7 @@ void MyProcess::on_finished(int exitCode, QProcess::ExitStatus exitStatus) {
 
 	isErrorExit =   (exitStatus != QProcess::NormalExit)
 	             || (exitCode != 0 && isWinShell)
-	             || !accError.isEmpty()
+//	             || !accError.isEmpty()
 	             ||  canceling;
 
 	if (!canceling) { // no more noise after cancel

--- a/src/myprocess.cpp
+++ b/src/myprocess.cpp
@@ -164,8 +164,12 @@ void MyProcess::on_finished(int exitCode, QProcess::ExitStatus exitStatus) {
 	accError += err;
 
 	isErrorExit =   (exitStatus != QProcess::NormalExit)
-	             || (exitCode != 0 && isWinShell)
-//	             || !accError.isEmpty()
+#ifdef Q_OS_WIN32
+	             || (exitCode && isWinShell)
+	             || !accError.isEmpty()
+#else
+	             || (exitCode && !accError.isEmpty())
+#endif
 	             ||  canceling;
 
 	if (!canceling) { // no more noise after cancel


### PR DESCRIPTION
I discovered that git config commands qgit invokes do return non-zero exit status.
But, fortunately, in these cases, nothing gets written to stderr.
So, the logic is, if not running windows, produce the command failed dialog only if
  exit code != 0  AND  not stderr.empty

I also removed the "Git says:" from the generic command failed dialog text because such commands may not invoke git.   In this case, saying "Git says" will be very misleading.
