### PR TITLE
Make Settings dialog accessible on macOS

### DIFF
--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -1716,7 +1716,7 @@ void MainImpl::doUpdateCustomActionMenu(const QStringList& list) {
 
 	Actions->addSeparator();
 	FOREACH_SL (it, list)
-		Actions->addAction(*it);
+		Actions->addAction(*it)->setMenuRole(QAction::NoRole);
 }
 
 void MainImpl::customAction_triggered(QAction* act) {

--- a/src/mainview.ui
+++ b/src/mainview.ui
@@ -285,6 +285,9 @@
    <property name="iconText">
     <string>Settings</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
+   </property>
   </action>
   <action name="ActCommit">
    <property name="enabled">
@@ -712,6 +715,9 @@
    </property>
    <property name="iconText">
     <string>Setup actions...</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="ActViewFileNewTab">


### PR DESCRIPTION
The `Settings` dialog was inaccessible on macOS because its menu item was being removed by Qt's menu role heuristic, and the `Setup actions` menu item took its place.

**Edit:** Amended to now also prevent suitably named custom actions from suffering the same fate as `Setup actions`.

Some screenshots to illustrate the problem and the solution.

### Before

No `Settings` item in the `Edit` Menu (expected), `Actions` menu missing when there are no actions:

![bad_editmenu](https://user-images.githubusercontent.com/304760/85223789-d7e10900-b3c5-11ea-91da-f797497bf404.png)

The `Preferences` item in the application menu is actually the `Setup actions` item, only betrayed by its icon:

![bad_appmenu](https://user-images.githubusercontent.com/304760/85223795-df081700-b3c5-11ea-9656-b698ee7bfc24.png)

### After

`Settings` appears as `Preferences` in the application menu:

![good_appmenu](https://user-images.githubusercontent.com/304760/85223799-e92a1580-b3c5-11ea-816d-6823680c8e66.png)

`Setup actions` is back in `Actions` where it belongs:

![good_actionsmenu](https://user-images.githubusercontent.com/304760/85223804-efb88d00-b3c5-11ea-901f-53e1fddbe73a.png)