### PR TITLE
Make drag & drop functionality optional

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -234,9 +234,10 @@ namespace QGit {
 		RANGE_SELECT_F  = 1 << 13,
 		REOPEN_REPO_F   = 1 << 14,
 		USE_CMT_MSG_F   = 1 << 15,
-		OPEN_IN_EDITOR_F = 1 << 16
+		OPEN_IN_EDITOR_F = 1 << 16,
+		ENABLE_DRAGNDROP_F = 1 << 17,
 	};
-	const int FLAGS_DEF = USE_CMT_MSG_F | RANGE_SELECT_F | SMART_LBL_F | VERIFY_CMT_F | SIGN_PATCH_F | LOG_DIFF_TAB_F | MSG_ON_NEW_F;
+	const int FLAGS_DEF = USE_CMT_MSG_F | RANGE_SELECT_F | SMART_LBL_F | VERIFY_CMT_F | SIGN_PATCH_F | LOG_DIFF_TAB_F | MSG_ON_NEW_F | ENABLE_DRAGNDROP_F;
 
 	// ShaString helpers
 	const ShaString toTempSha(const QString&); // use as argument only, see definition

--- a/src/filelist.cpp
+++ b/src/filelist.cpp
@@ -147,7 +147,7 @@ bool FileList::startDragging(QMouseEvent* /*e*/) {
 }
 
 void FileList::mouseMoveEvent(QMouseEvent* e) {
-	if (e->buttons() == Qt::LeftButton)
+	if (e->buttons() == Qt::LeftButton && QGit::testFlag(QGit::ENABLE_DRAGNDROP_F))
 		if (startDragging(e)) return;
 
 	QListWidget::mouseMoveEvent(e);

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -413,7 +413,7 @@ void ListView::startDragging(QMouseEvent* /*e*/) {
 
 void ListView::mouseMoveEvent(QMouseEvent* e) {
 
-	if (e->buttons() == Qt::LeftButton) {
+	if (e->buttons() == Qt::LeftButton && QGit::testFlag(QGit::ENABLE_DRAGNDROP_F)) {
 		startDragging(e);
 		return;
 	}

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -204,6 +204,7 @@ MainImpl::MainImpl(SCRef cd, QWidget* p) : QMainWindow(p) {
 
 void MainImpl::initWithEventLoopActive() {
 
+	emit flagChanged(QGit::ENABLE_DRAGNDROP_F);
 	git->checkEnvironment();
 	setRepository(startUpDir);
 	startUpDir = ""; // one shot

--- a/src/revsview.cpp
+++ b/src/revsview.cpp
@@ -46,6 +46,8 @@ RevsView::RevsView(MainImpl* mi, Git* g, bool isMain) : Domain(mi, g, isMain) {
 	connect(m(), SIGNAL(flagChanged(uint)),
 	        sb, SLOT(flagChanged(uint)));
 
+	connect(m(), SIGNAL(flagChanged(uint)), SLOT(on_flagChanged(uint)));
+
 	connect(git, SIGNAL(newRevsAdded(const FileHistory*, const QVector<ShaString>&)),
 	        this, SLOT(on_newRevsAdded(const FileHistory*, const QVector<ShaString>&)));
 
@@ -231,6 +233,17 @@ void RevsView::on_updateRevDesc() {
 
 	SCRef d = m()->getRevisionDesc(st.sha());
 	tab()->textBrowserDesc->setHtml(d);
+}
+
+void RevsView::on_flagChanged(uint flag) {
+
+	if (flag == QGit::ENABLE_DRAGNDROP_F) {
+		if (QGit::testFlag(QGit::ENABLE_DRAGNDROP_F)) {
+			tab()->listViewLog->setSelectionMode(QAbstractItemView::ExtendedSelection);
+		} else {
+			tab()->listViewLog->setSelectionMode(QAbstractItemView::SingleSelection);
+		}
+	}
 }
 
 bool RevsView::doUpdate(bool force) {

--- a/src/revsview.h
+++ b/src/revsview.h
@@ -36,6 +36,7 @@ private slots:
 	void on_loadCompleted(const FileHistory*, const QString& stats);
 	void on_lanesContextMenuRequested(const QStringList&, const QStringList&);
 	void on_updateRevDesc();
+	void on_flagChanged(uint flag);
 
 protected:
 	virtual bool doUpdate(bool force);

--- a/src/revsview.ui
+++ b/src/revsview.ui
@@ -34,9 +34,6 @@
       <property name="alternatingRowColors" >
        <bool>true</bool>
       </property>
-      <property name="selectionMode" >
-       <enum>QAbstractItemView::ExtendedSelection</enum>
-      </property>
       <property name="rootIsDecorated" >
        <bool>false</bool>
       </property>

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -500,6 +500,16 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxEnableDragnDrop">
+                <property name="toolTip">
+                 <string>Check to enable Git operations, etc. via drag &amp; drop</string>
+                </property>
+                <property name="text">
+                 <string>Enable drag &amp;&amp; drop</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
            </layout>
@@ -1652,6 +1662,22 @@
     <hint type="destinationlabel">
      <x>256</x>
      <y>236</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBoxEnableDragnDrop</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>settingsBase</receiver>
+   <slot>checkBoxEnableDragnDrop_toggled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>93</x>
+     <y>140</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>510</x>
+     <y>182</y>
     </hint>
    </hints>
   </connection>

--- a/src/settingsimpl.cpp
+++ b/src/settingsimpl.cpp
@@ -55,6 +55,7 @@ SettingsImpl::SettingsImpl(QWidget* p, Git* g, int defTab) : QDialog(p), git(g) 
 	checkBoxLogDiffTab->setChecked(f & LOG_DIFF_TAB_F);
 	checkBoxSmartLabels->setChecked(f & SMART_LBL_F);
 	checkBoxMsgOnNewSHA->setChecked(f & MSG_ON_NEW_F);
+	checkBoxEnableDragnDrop->setChecked(f & ENABLE_DRAGNDROP_F);
 
 	QSettings set;
 	SCRef APOpt(set.value(AM_P_OPT_KEY).toString());
@@ -312,6 +313,11 @@ void SettingsImpl::checkBoxSmartLabels_toggled(bool b) {
 void SettingsImpl::checkBoxMsgOnNewSHA_toggled(bool b) {
 
 	changeFlag(MSG_ON_NEW_F, b);
+}
+
+void SettingsImpl::checkBoxEnableDragnDrop_toggled(bool b) {
+
+	changeFlag(ENABLE_DRAGNDROP_F, b);
 }
 
 void SettingsImpl::checkBoxCommitSign_toggled(bool b) {

--- a/src/settingsimpl.h
+++ b/src/settingsimpl.h
@@ -31,6 +31,7 @@ protected slots:
 	void checkBoxLogDiffTab_toggled(bool b);
 	void checkBoxSmartLabels_toggled(bool b);
 	void checkBoxMsgOnNewSHA_toggled(bool b);
+	void checkBoxEnableDragnDrop_toggled(bool b);
 	void checkBoxDiffCache_toggled(bool b);
 	void checkBoxCommitSign_toggled(bool b);
 	void checkBoxCommitVerify_toggled(bool b);


### PR DESCRIPTION
Adds an `Enable drag & drop` toggle to the `Settings` dialog. Defaults to enabled. Fixes #84

![dragndrop](https://user-images.githubusercontent.com/304760/85224067-e29c9d80-b3c7-11ea-9154-12c5876212b6.png)