### PR TITLE
Fix loading of invalid cache file

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -145,11 +145,17 @@ bool Cache::load(const QString& gitDir, RevFileMap& rfm,
 	stream >> revsFilesShaBuf;
 
 	const char* data = revsFilesShaBuf.constData();
+	const char* endptr = &*revsFilesShaBuf.constEnd();
 
 	while (!stream.atEnd()) {
 
 		RevFile* rf = new RevFile();
 		*rf << stream;
+
+		if (data > endptr - 41) {
+			dbs("ASSERT in Cache::load, corrupted SHA");
+			return false;
+		}
 
 		ShaString sha(data);
 		rfm.insert(sha, rf);

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -2281,7 +2281,6 @@ bool Git::init(SCRef wd, bool askForRange, const QStringList* passedArgs, bool o
                         bool dummy;
                         getBaseDir(wd, workDir, dummy);
                         localDates.clear();
-                        clearFileNames();
                         fileCacheAccessed = false;
 
                         SHOW_MSG(msg1 + "file names cache...");
@@ -2524,12 +2523,17 @@ void Git::loadFileCache() {
         if (!fileCacheAccessed) {
 
                 fileCacheAccessed = true;
+                clearFileNames();
                 QByteArray shaBuf;
                 if (Cache::load(gitDir, revsFiles, dirNamesVec, fileNamesVec, shaBuf)) {
                         revsFilesShaBackupBuf.append(shaBuf);
                         populateFileNamesMap();
-                } else
+                } else {
+                        // The cache isn't valid. Clear it before we corrupt it
+                        // by freeing `shaBuf`.
+                        clearFileNames();
                         dbs("ERROR: unable to load file names cache");
+                }
         }
 }
 


### PR DESCRIPTION
Avoid corrupting memory by clearing the cache before freeing it's content.
Also adds a bounds check on the sha array.

Fix #69
Fix #71