### PR TITLE
Cleanup Qt4 compatibility, raise Qt minimum to 5.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,28 +17,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 
-option(UseQt5 "Use Qt5?" ON)
-if (UseQt5)
-  find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
-  set(QT_LIBRARIES Qt5::Widgets)
-
-  macro(qt_wrap_ui)
-    qt5_wrap_ui(${ARGN})
-  endmacro()
-  macro(qt_add_resources)
-    qt5_add_resources(${ARGN})
-  endmacro()
-else()
-  find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui)
-  include(${QT_USE_FILE})
-
-  macro(qt_wrap_ui)
-    qt4_wrap_ui(${ARGN})
-  endmacro()
-  macro(qt_add_resources)
-    qt4_add_resources(${ARGN})
-  endmacro()
-endif()
+set(QT_MIN_VERSION 5.6.0)
+find_package(Qt5 ${QT_MIN_VERSION} REQUIRED COMPONENTS Core Gui Widgets)
 
 include_directories(
     ${CMAKE_SOURCE_DIR}/src
@@ -77,7 +57,7 @@ set(CPP_SOURCES
 )
 
 # UIS_HDRS will be used later in add_executable
-QT_WRAP_UI(UIS_HDRS
+qt5_wrap_ui(UIS_HDRS
     src/commit.ui
     src/console.ui
     src/customaction.ui
@@ -91,16 +71,16 @@ QT_WRAP_UI(UIS_HDRS
 )
 
 # and finally an resource file
-SET(RESOURCE_FILES
+set(RESOURCE_FILES
     src/icons.qrc
 )
 
 # this command will generate rules that will run rcc on all files from SAMPLE_RCS
 # in result SAMPLE_RC_SRCS variable will contain paths to files produced by rcc
-QT_ADD_RESOURCES(RC_SRCS ${RESOURCE_FILES})
+qt5_add_resources(RC_SRCS ${RESOURCE_FILES})
 
 add_executable(qgit ${CPP_SOURCES} ${UIS_HDRS} ${RC_SRCS})
-target_link_libraries(qgit ${QT_LIBRARIES})
+target_link_libraries(qgit Qt5::Widgets)
 
 
 install(TARGETS qgit DESTINATION bin)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -265,9 +265,5 @@ RevFile& RevFile::operator<<(QDataStream& stream) {
 }
 
 QString qt4and5escaping(QString toescape) {
-#if QT_VERSION >= 0x050000
-	return toescape.toHtmlEscaped();
-#else
-	return Qt::escape(toescape);
-#endif
+    return toescape.toHtmlEscaped();
 }

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -1930,12 +1930,8 @@ Rev* Git::fakeRevData(SCRef sha, SCList parents, SCRef author, SCRef date, SCRef
         if (!patch.isEmpty())
                 data.append('\n' + patch);
 
-#if QT_VERSION >= 0x050000
         QTextCodec* tc = QTextCodec::codecForLocale();
         QByteArray* ba = new QByteArray(tc->fromUnicode(data));
-#else
-        QByteArray* ba = new QByteArray(data.toLatin1());
-#endif
         ba->append('\0');
 
         fh->rowData.append(ba);

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -100,15 +100,9 @@ void ListView::setupGeometry() {
 
 	QHeaderView* hv = header();
 	hv->setStretchLastSection(true);
-#if QT_VERSION >= 0x050000
 	hv->setSectionResizeMode(LOG_COL, QHeaderView::Interactive);
 	hv->setSectionResizeMode(TIME_COL, QHeaderView::Interactive);
 	hv->setSectionResizeMode(ANN_ID_COL, QHeaderView::ResizeToContents);
-#else
-	hv->setResizeMode(LOG_COL, QHeaderView::Interactive);
-	hv->setResizeMode(TIME_COL, QHeaderView::Interactive);
-	hv->setResizeMode(ANN_ID_COL, QHeaderView::ResizeToContents);
-#endif
 	hv->resizeSection(GRAPH_COL, DEF_GRAPH_COL_WIDTH);
 	hv->resizeSection(LOG_COL, DEF_LOG_COL_WIDTH);
 	hv->resizeSection(AUTH_COL, DEF_AUTH_COL_WIDTH);
@@ -1177,11 +1171,7 @@ QString ListView::refNameAt(const QPoint &pos)
  * Return the device pixel ratio
  */
 qreal ListViewDelegate::dpr(void) const {
-#if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
-    return qApp->devicePixelRatio();
-#else
-    return 1.0;
-#endif
+	return qApp->devicePixelRatio();
 }
 
 void ListViewDelegate::addTextPixmap(QPixmap** pp, SCRef txt, const QStyleOptionViewItem& opt) const {
@@ -1201,9 +1191,7 @@ void ListViewDelegate::addTextPixmap(QPixmap** pp, SCRef txt, const QStyleOption
 			 static_cast<int>(text_height * dpr()));
 
 	QPixmap* newPm = new QPixmap(pixmapSize);
-#if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
-    newPm->setDevicePixelRatio(dpr());
-#endif
+	newPm->setDevicePixelRatio(dpr());
 
 	QPainter p;
 	p.begin(newPm);

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -87,25 +87,14 @@ MainImpl::MainImpl(SCRef cd, QWidget* p) : QMainWindow(p) {
 	QSettings settings;
 	QString font(settings.value(STD_FNT_KEY).toString());
 	if (font.isEmpty()) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5,2,0))
 		font = QFontDatabase::systemFont(QFontDatabase::GeneralFont).toString();
-#else
-		font = QApplication::font().toString();
-#endif
 	}
 	QGit::STD_FONT.fromString(font);
 
 	// set-up typewriter (fixed width) font
 	font = settings.value(TYPWRT_FNT_KEY).toString();
 	if (font.isEmpty()) { // choose a sensible default
-#if (QT_VERSION >= QT_VERSION_CHECK(5,2,0))
 		QFont fnt = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-#else
-		QFont fnt = QApplication::font();
-		fnt.setStyleHint(QFont::TypeWriter, QFont::PreferDefault);
-		fnt.setFixedPitch(true);
-		fnt.setFamily(fnt.defaultFamily()); // the family corresponding
-#endif
 		font = fnt.toString();              // to current style hint
 	}
 	QGit::TYPE_WRITER_FONT.fromString(font);
@@ -1143,11 +1132,7 @@ void MainImpl::shortCutActivated() {
 	QShortcut* se = dynamic_cast<QShortcut*>(sender());
 
 	if (se) {
-#if QT_VERSION >= 0x050000
 		const QKeySequence& key = se->key();
-#else
-		const int key = se->key();
-#endif
 
 		if (key == Qt::Key_I) {
 			rv->tab()->listViewLog->on_keyUp();

--- a/src/qgit.cpp
+++ b/src/qgit.cpp
@@ -18,10 +18,8 @@ using namespace QGit;
 int main(int argc, char* argv[]) {
 
 	QApplication app(argc, argv);
-#if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
-    app.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
-#endif
-    QCoreApplication::setOrganizationName(ORG_KEY);
+	app.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
+	QCoreApplication::setOrganizationName(ORG_KEY);
 	QCoreApplication::setApplicationName(APP_KEY);
 
 	/* On Windows msysgit exec directory is set up


### PR DESCRIPTION
While Qt4 is unmaintained for several years and itself fails to build
on modern systems, qgit build with Qt4 was broken by commits b68c3e76
and 3f25d12a and no one seems to have noticed in ~two years.

Rather than fix it, it is probably time to clean it up altogether.

This commit does not fix qmake build system which seems to have more
issues, it should probably be dropped as well in favor of CMake.