### PR TITLE
Fix build on MacOS

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,7 +45,7 @@ To compile, install and start qgit:
 
  - generate Makefiles (only the first time)
    Unix/Linux and Windows:  qmake qgit.pro
-   Mac Os X:                qmake -spec macx-g++ qgit.pro
+   Mac Os X:                qmake -spec macx-clang qgit.pro
 
  - (Windows only with VC2008 IDE) open qgit.sln solution file
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -40,7 +40,7 @@ win32 {
     RC_FILE = app_icon.rc
 }
 
-unix {
+unix:!macx {
     TARGET = qgit
     target.path = $$[QT_INSTALL_BINS]
     CONFIG += x11


### PR DESCRIPTION
Remove linking aginst X11 on MacOS.
Compiled successfully with Qt5 installed with brew.