### PR TITLE
Address compiler warnings about deprecated QTime::start

### DIFF
--- a/src/annotate.h
+++ b/src/annotate.h
@@ -7,8 +7,8 @@
 #ifndef ANNOTATE_H
 #define ANNOTATE_H
 
+#include <QElapsedTimer>
 #include <QObject>
-#include <QTime>
 #include "exceptionmanager.h"
 #include "common.h"
 
@@ -78,7 +78,7 @@ private:
 	ShaVect histRevOrder; // TODO use reference
 	bool valid;
 	bool canceled;
-	QTime processingTime;
+	QElapsedTimer processingTime;
 	Ranges ranges;
 };
 

--- a/src/common.h
+++ b/src/common.h
@@ -19,7 +19,7 @@
 /*
    QVariant does not support size_t type used in Qt containers, this is
    a problem on 64bit systems where size_t != uint and when using debug
-   macros on size_t variables, as example dbg(vector.count()), a compile
+   macros on size_t variables, as example dbs(vector.count()), a compile
    error occurs.
    Workaround this using a function template and a specialization.
    Function _valueOf() is used by debug macros
@@ -31,15 +31,8 @@ inline const QString  _valueOf(size_t x) { return QString::number((uint)x); }
 
 // some debug macros
 #define constlatin(x) (_valueOf(x).toLatin1().constData())
-#define dbg(x)    qDebug(#x " is <%s>", constlatin(x))
 #define dbs(x)    qDebug(constlatin(x), "")
 #define dbp(s, x) qDebug(constlatin(_valueOf(s).arg(x)), "")
-#define db1       qDebug("Mark Nr. 1")
-#define db2       qDebug("Mark Nr. 2")
-#define db3       qDebug("Mark Nr. 3")
-#define db4       qDebug("Mark Nr. 4")
-#define dbStart   dbs("Starting timer..."); QTime _t; _t.start()
-#define dbRestart dbp("Elapsed time is %1 ms", _t.restart())
 
 // some syntactic sugar
 #define FOREACH(type, i, c) for (type::const_iterator i((c).constBegin()),    \

--- a/src/dataloader.h
+++ b/src/dataloader.h
@@ -7,8 +7,8 @@
 #ifndef DATALOADER_H
 #define DATALOADER_H
 
+#include <QElapsedTimer>
 #include <QProcess>
-#include <QTime>
 #include <QTimer>
 
 class Git;
@@ -48,7 +48,7 @@ private:
 	FileHistory* fh;
 	QByteArray* halfChunk;
 	UnbufferedTemporaryFile* dataFile;
-	QTime loadTime;
+	QElapsedTimer loadTime;
 	QTimer guiUpdateTimer;
 	ulong loadedBytes;
 	bool isProcExited;

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -7,6 +7,7 @@
 
 */
 #include <QApplication>
+#include <QDateTime>
 #include <QDir>
 #include <QFile>
 #include <QImageReader>

--- a/src/myprocess.cpp
+++ b/src/myprocess.cpp
@@ -7,7 +7,7 @@
 
 */
 #include <QApplication>
-#include <QTime>
+#include <QElapsedTimer>
 #include "exceptionmanager.h"
 #include "common.h"
 #include "domain.h"
@@ -49,7 +49,7 @@ bool MyProcess::runSync(SCRef rc, QByteArray* ro, QObject* rcv, SCRef buf) {
 	if (!launchMe(runCmd, buf))
 		return false;
 
-	QTime t;
+	QElapsedTimer t;
 	t.start();
 
 	busy = true; // we have to wait here until we exit

--- a/src/smartbrowse.h
+++ b/src/smartbrowse.h
@@ -7,8 +7,8 @@
 #ifndef SMARTBROWSE_H
 #define SMARTBROWSE_H
 
+#include <QElapsedTimer>
 #include <QLabel>
-#include <QTime>
 #include "revsview.h"
 
 class SmartLabel : public QLabel {
@@ -49,7 +49,7 @@ private:
 	SmartLabel* logBottomLbl;
 	SmartLabel* diffTopLbl;
 	SmartLabel* diffBottomLbl;
-	QTime scrollTimer, switchTimer, timeoutTimer;
+	QElapsedTimer scrollTimer, switchTimer, timeoutTimer;
 	int wheelCnt;
 	bool lablesEnabled;
 };


### PR DESCRIPTION
Replace `QTime` by `QElapsedTimer` of Qt >=4.7
    
Docs:
https://doc.qt.io/qt-5/qelapsedtimer.html
    
Addresses this compiler warning:
```
warning: ‘void QTime::start()’ is deprecated: Use QElapsedTimer instead [-Wdeprecated-declarations]
```
