### PR TITLE
Address compiler warnings about deprecated QString::SplitBehavior for compiling with Qt >=5.14

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -16,6 +16,13 @@
 #include <QVariant>
 #include <QVector>
 
+// QString::SplitBehavior becomes Qt::SplitBehavior in Qt 5.14
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+# define QGIT_SPLITBEHAVIOR(x) Qt::x
+#else
+# define QGIT_SPLITBEHAVIOR(x) QString::x
+#endif
+
 /*
    QVariant does not support size_t type used in Qt containers, this is
    a problem on 64bit systems where size_t != uint and when using debug

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -142,7 +142,7 @@ const QStringList Git::getGitConfigList(bool global) {
 
     errorReportingEnabled = true;
 
-    return runOutput.split('\n', Qt::SkipEmptyParts);
+    return runOutput.split('\n', QGIT_SPLITBEHAVIOR(SkipEmptyParts));
 }
 
 bool Git::isImageFile(SCRef file) {
@@ -805,7 +805,7 @@ bool Git::getTree(SCRef treeSha, TreeInfo& ti, bool isWorkingDir, SCRef path) {
 	if (!tree.isEmpty() && !run("git ls-tree " + tree, &runOutput))
 		return false;
 
-	const QStringList sl(runOutput.split('\n', Qt::SkipEmptyParts));
+	const QStringList sl(runOutput.split('\n', QGIT_SPLITBEHAVIOR(SkipEmptyParts)));
 	FOREACH_SL (it, sl) {
 
 		// append any not deleted file
@@ -1318,7 +1318,7 @@ bool Git::getPatchFilter(SCRef exp, bool isRegExp, ShaSet& shaSet) {
 	if (!run(runCmd, &runOutput, NULL, buf))
 		return false;
 
-	const QStringList sl(runOutput.split('\n', Qt::SkipEmptyParts));
+	const QStringList sl(runOutput.split('\n', QGIT_SPLITBEHAVIOR(SkipEmptyParts)));
 	FOREACH_SL (it, sl)
 		shaSet.insert(*it);
 
@@ -1803,7 +1803,7 @@ bool Git::getRefs() {
 
         QString prevRefSha;
         QStringList patchNames, patchShas;
-        const QStringList rLst(runOutput.split('\n', Qt::SkipEmptyParts));
+        const QStringList rLst(runOutput.split('\n', QGIT_SPLITBEHAVIOR(SkipEmptyParts)));
         FOREACH_SL (it, rLst) {
 
                 SCRef revSha = (*it).left(40);
@@ -1884,7 +1884,7 @@ void Git::parseStGitPatches(SCList patchNames, SCList patchShas) {
         if (!run("stg series", &runOutput))
                 return;
 
-        const QStringList pl(runOutput.split('\n', Qt::SkipEmptyParts));
+        const QStringList pl(runOutput.split('\n', QGIT_SPLITBEHAVIOR(SkipEmptyParts)));
         FOREACH_SL (it, pl) {
 
                 SCRef status = (*it).left(1);
@@ -1924,7 +1924,7 @@ const QStringList Git::getOthersFiles() {
 
         QString runOutput;
         run(runCmd, &runOutput);
-        return runOutput.split('\n', Qt::SkipEmptyParts);
+        return runOutput.split('\n', QGIT_SPLITBEHAVIOR(SkipEmptyParts));
 }
 
 Rev* Git::fakeRevData(SCRef sha, SCList parents, SCRef author, SCRef date, SCRef log, SCRef longLog,
@@ -2083,7 +2083,7 @@ void Git::setStatus(RevFile& rf, SCRef rowSt) {
 
 void Git::setExtStatus(RevFile& rf, SCRef rowSt, int parNum, FileNamesLoader& fl) {
 
-        const QStringList sl(rowSt.split('\t', Qt::SkipEmptyParts));
+        const QStringList sl(rowSt.split('\t', QGIT_SPLITBEHAVIOR(SkipEmptyParts)));
         if (sl.count() != 3) {
                 dbp("ASSERT in setExtStatus, unexpected status string %1", rowSt);
                 return;

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -142,7 +142,7 @@ const QStringList Git::getGitConfigList(bool global) {
 
     errorReportingEnabled = true;
 
-    return runOutput.split('\n', QString::SkipEmptyParts);
+    return runOutput.split('\n', Qt::SkipEmptyParts);
 }
 
 bool Git::isImageFile(SCRef file) {
@@ -805,7 +805,7 @@ bool Git::getTree(SCRef treeSha, TreeInfo& ti, bool isWorkingDir, SCRef path) {
 	if (!tree.isEmpty() && !run("git ls-tree " + tree, &runOutput))
 		return false;
 
-	const QStringList sl(runOutput.split('\n', QString::SkipEmptyParts));
+	const QStringList sl(runOutput.split('\n', Qt::SkipEmptyParts));
 	FOREACH_SL (it, sl) {
 
 		// append any not deleted file
@@ -1318,7 +1318,7 @@ bool Git::getPatchFilter(SCRef exp, bool isRegExp, ShaSet& shaSet) {
 	if (!run(runCmd, &runOutput, NULL, buf))
 		return false;
 
-	const QStringList sl(runOutput.split('\n', QString::SkipEmptyParts));
+	const QStringList sl(runOutput.split('\n', Qt::SkipEmptyParts));
 	FOREACH_SL (it, sl)
 		shaSet.insert(*it);
 
@@ -1803,7 +1803,7 @@ bool Git::getRefs() {
 
         QString prevRefSha;
         QStringList patchNames, patchShas;
-        const QStringList rLst(runOutput.split('\n', QString::SkipEmptyParts));
+        const QStringList rLst(runOutput.split('\n', Qt::SkipEmptyParts));
         FOREACH_SL (it, rLst) {
 
                 SCRef revSha = (*it).left(40);
@@ -1884,7 +1884,7 @@ void Git::parseStGitPatches(SCList patchNames, SCList patchShas) {
         if (!run("stg series", &runOutput))
                 return;
 
-        const QStringList pl(runOutput.split('\n', QString::SkipEmptyParts));
+        const QStringList pl(runOutput.split('\n', Qt::SkipEmptyParts));
         FOREACH_SL (it, pl) {
 
                 SCRef status = (*it).left(1);
@@ -1924,7 +1924,7 @@ const QStringList Git::getOthersFiles() {
 
         QString runOutput;
         run(runCmd, &runOutput);
-        return runOutput.split('\n', QString::SkipEmptyParts);
+        return runOutput.split('\n', Qt::SkipEmptyParts);
 }
 
 Rev* Git::fakeRevData(SCRef sha, SCList parents, SCRef author, SCRef date, SCRef log, SCRef longLog,
@@ -2083,7 +2083,7 @@ void Git::setStatus(RevFile& rf, SCRef rowSt) {
 
 void Git::setExtStatus(RevFile& rf, SCRef rowSt, int parNum, FileNamesLoader& fl) {
 
-        const QStringList sl(rowSt.split('\t', QString::SkipEmptyParts));
+        const QStringList sl(rowSt.split('\t', Qt::SkipEmptyParts));
         if (sl.count() != 3) {
                 dbp("ASSERT in setExtStatus, unexpected status string %1", rowSt);
                 return;

--- a/src/inputdialog.cpp
+++ b/src/inputdialog.cpp
@@ -94,7 +94,7 @@ InputDialog::InputDialog(const QString &cmd, const VariableMap &variables,
 	int row = 0;
 	while ((start = re.indexIn(cmd, start)) != -1) {
 		const QString type = re.cap(2);
-		const QStringList opts = re.cap(4).split(',', Qt::SkipEmptyParts);
+		const QStringList opts = re.cap(4).split(',', QGIT_SPLITBEHAVIOR(SkipEmptyParts));
 		const QString name = re.cap(5);
 		const QString value = re.cap(6).mid(1);
 		if (widgets.count(name)) { // widget already created

--- a/src/inputdialog.cpp
+++ b/src/inputdialog.cpp
@@ -94,7 +94,7 @@ InputDialog::InputDialog(const QString &cmd, const VariableMap &variables,
 	int row = 0;
 	while ((start = re.indexIn(cmd, start)) != -1) {
 		const QString type = re.cap(2);
-		const QStringList opts = re.cap(4).split(',', QString::SkipEmptyParts);
+		const QStringList opts = re.cap(4).split(',', Qt::SkipEmptyParts);
 		const QString name = re.cap(5);
 		const QString value = re.cap(6).mid(1);
 		if (widgets.count(name)) { // widget already created

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -491,7 +491,7 @@ void ListView::dragEnterEvent(QDragEnterEvent* e) {
 
 	SCRef revsText(e->mimeData()->data("application/x-qgit-revs"));
 	QString header = revsText.section("\n", 0, 0);
-	dropInfo->shas = revsText.section("\n", 1).split('\n', Qt::SkipEmptyParts);
+	dropInfo->shas = revsText.section("\n", 1).split('\n', QGIT_SPLITBEHAVIOR(SkipEmptyParts));
 	// extract refname and sha from first entry again
 	dropInfo->sourceRef = dropInfo->shas.front().section(" ", 1);
 	dropInfo->shas.front() = dropInfo->shas.front().section(" ", 0, 0);

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -491,7 +491,7 @@ void ListView::dragEnterEvent(QDragEnterEvent* e) {
 
 	SCRef revsText(e->mimeData()->data("application/x-qgit-revs"));
 	QString header = revsText.section("\n", 0, 0);
-	dropInfo->shas = revsText.section("\n", 1).split('\n', QString::SkipEmptyParts);
+	dropInfo->shas = revsText.section("\n", 1).split('\n', Qt::SkipEmptyParts);
 	// extract refname and sha from first entry again
 	dropInfo->sourceRef = dropInfo->shas.front().section(" ", 1);
 	dropInfo->shas.front() = dropInfo->shas.front().section(" ", 0, 0);

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -1309,7 +1309,7 @@ void MainImpl::doUpdateRecentRepoMenu(SCRef newEntry) {
 static void prepareRefSubmenu(QMenu* menu, const QStringList& refs, const QChar sep = '/') {
 
 	FOREACH_SL (it, refs) {
-		const QStringList& parts(it->split(sep, Qt::SkipEmptyParts));
+		const QStringList& parts(it->split(sep, QGIT_SPLITBEHAVIOR(SkipEmptyParts)));
 		QMenu* add_here = menu;
 		FOREACH_SL (pit, parts) {
 			if (pit == parts.end() - 1) break;

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -1309,7 +1309,7 @@ void MainImpl::doUpdateRecentRepoMenu(SCRef newEntry) {
 static void prepareRefSubmenu(QMenu* menu, const QStringList& refs, const QChar sep = '/') {
 
 	FOREACH_SL (it, refs) {
-		const QStringList& parts(it->split(sep, QString::SkipEmptyParts));
+		const QStringList& parts(it->split(sep, Qt::SkipEmptyParts));
 		QMenu* add_here = menu;
 		FOREACH_SL (pit, parts) {
 			if (pit == parts.end() - 1) break;

--- a/src/myprocess.cpp
+++ b/src/myprocess.cpp
@@ -208,7 +208,7 @@ const QStringList MyProcess::splitArgList(SCRef cmd) {
 	if (!(   cmd.contains(QGit::QUOTE_CHAR)
 	      || cmd.contains("\"")
 	      || cmd.contains("\'")))
-		return cmd.split(' ', Qt::SkipEmptyParts);
+		return cmd.split(' ', QGIT_SPLITBEHAVIOR(SkipEmptyParts));
 
 	// we have some work to do...
 	// first find a possible separator
@@ -238,7 +238,7 @@ const QStringList MyProcess::splitArgList(SCRef cmd) {
 
 	// QProcess::setArguments doesn't want quote
 	// delimited arguments, so remove trailing quotes
-	QStringList sl(newCmd.split(sepChar, Qt::SkipEmptyParts));
+	QStringList sl(newCmd.split(sepChar, QGIT_SPLITBEHAVIOR(SkipEmptyParts)));
 	QStringList::iterator it(sl.begin());
 	for ( ; it != sl.end(); ++it) {
 		if (((*it).left(1) == "\"" && (*it).right(1) == "\"") ||

--- a/src/myprocess.cpp
+++ b/src/myprocess.cpp
@@ -208,7 +208,7 @@ const QStringList MyProcess::splitArgList(SCRef cmd) {
 	if (!(   cmd.contains(QGit::QUOTE_CHAR)
 	      || cmd.contains("\"")
 	      || cmd.contains("\'")))
-		return cmd.split(' ', QString::SkipEmptyParts);
+		return cmd.split(' ', Qt::SkipEmptyParts);
 
 	// we have some work to do...
 	// first find a possible separator
@@ -238,7 +238,7 @@ const QStringList MyProcess::splitArgList(SCRef cmd) {
 
 	// QProcess::setArguments doesn't want quote
 	// delimited arguments, so remove trailing quotes
-	QStringList sl(newCmd.split(sepChar, QString::SkipEmptyParts));
+	QStringList sl(newCmd.split(sepChar, Qt::SkipEmptyParts));
 	QStringList::iterator it(sl.begin());
 	for ( ; it != sl.end(); ++it) {
 		if (((*it).left(1) == "\"" && (*it).right(1) == "\"") ||

--- a/src/patchcontent.cpp
+++ b/src/patchcontent.cpp
@@ -236,7 +236,7 @@ void PatchContent::processData(const QByteArray& fileChunk, int* prevLineNum) {
 	if (prevLineNum && prevFilter == VIEW_ALL)
 		*prevLineNum = -(*prevLineNum); // set once
 
-	const QStringList sl(newLines.split('\n', QString::KeepEmptyParts));
+	const QStringList sl(newLines.split('\n', Qt::KeepEmptyParts));
 	FOREACH_SL (it, sl) {
 
 		// do not remove diff header because of centerTarget

--- a/src/patchcontent.cpp
+++ b/src/patchcontent.cpp
@@ -236,7 +236,7 @@ void PatchContent::processData(const QByteArray& fileChunk, int* prevLineNum) {
 	if (prevLineNum && prevFilter == VIEW_ALL)
 		*prevLineNum = -(*prevLineNum); // set once
 
-	const QStringList sl(newLines.split('\n', Qt::KeepEmptyParts));
+	const QStringList sl(newLines.split('\n', QGIT_SPLITBEHAVIOR(KeepEmptyParts)));
 	FOREACH_SL (it, sl) {
 
 		// do not remove diff header because of centerTarget


### PR DESCRIPTION
Replace `QString::SplitBehavior` by `Qt::SplitBehavior` of Qt >=5.14

Docs:
- https://doc.qt.io/qt-5/qstring.html#split
- https://doc.qt.io/qt-5/qt.html#SplitBehaviorFlags-enum

Addresses this compiler warning:
```
warning: ‘QStringList QString::split(QChar, QString::SplitBehavior, Qt::CaseSensitivity) const’ is deprecated: Use Qt::SplitBehavior variant instead [-Wdeprecated-declarations]
```