### PR TITLE
CMake: Address warning about compatibility with CMake 2.x.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # see also http://stackoverflow.com/questions/16245147/unable-to-include-a-ui-form-header-of-qt5-in-cmake
 # see also http://www.qtcentre.org/wiki/index.php?title=Compiling_Qt4_apps_with_CMake
 #
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.10.2)
 
 project(qgit)
 include(GNUInstallDirs)


### PR DESCRIPTION
@tibirna just an idea, with a rather conservative new version value for a start (see below), happy to discuss.

Warnings was:

> CMake Deprecation Warning at CMakeLists.txt:8 (cmake_minimum_required):
>   Compatibility with CMake < 2.8.12 will be removed from a future version of
>   CMake.
>
>   Update the VERSION argument <min> value or use a ...<max> suffix to tell
>   CMake that the project does not need compatibility with older versions.

CMake in the wild is at:

```
Debian oldstable/buster 3.13.4-1
Debian stable/bullseye  3.18.4-2
Gentoo stable           3.20.5
Gentoo unstable         3.21.2
Ubuntu 18.04LTS/bionic  3.10.2-1ubuntu2
Ubuntu 20.04LTS/focal   3.16.3-1ubuntu1
Ubuntu 21.04/hirsute    3.18.4-2ubuntu1
```