### PR TITLE
FileHistory: Add "Short Hash" column.

### DIFF
--- a/src/FileHistory.cc
+++ b/src/FileHistory.cc
@@ -21,7 +21,7 @@ using namespace QGit;
 
 FileHistory::FileHistory(QObject* p, Git* g) : QAbstractItemModel(p), git(g) {
 
-  headerInfo << "Graph" << "Id" << "Short Log" << "Author" << "Author Date";
+  headerInfo << "Graph" << "Id" << "Short Log" << "Short Hash" << "Author" << "Author Date";
   lns = new Lanes();
   revs.reserve(QGit::MAX_DICT_SIZE);
   clear(); // after _headerInfo is set
@@ -237,8 +237,11 @@ QVariant FileHistory::data(const QModelIndex& index, int role) const {
 
   static const QVariant no_value;
 
-  if (!index.isValid() || role != Qt::DisplayRole)
+  if (!index.isValid() || role != Qt::DisplayRole) {
+    if (role == Qt::FontRole && index.column() == QGit::HASH_COL)
+        return QGit::TYPE_WRITER_FONT;
     return no_value; // fast path, 90% of calls ends here!
+  }
 
   const Rev* r = git->revLookup(revOrder.at(index.row()), this);
   if (!r)
@@ -255,6 +258,9 @@ QVariant FileHistory::data(const QModelIndex& index, int role) const {
 
   if (col == QGit::LOG_COL)
     return r->shortLog();
+
+  if (col == QGit::HASH_COL)
+    return r->shortHash(git->shortHashLength());
 
   if (col == QGit::AUTH_COL)
     return r->author();

--- a/src/FileHistory.h
+++ b/src/FileHistory.h
@@ -39,7 +39,7 @@ public:
   virtual QModelIndex parent(const QModelIndex& index) const;
   virtual int rowCount(const QModelIndex& par = QModelIndex()) const;
   virtual bool hasChildren(const QModelIndex& par = QModelIndex()) const;
-  virtual int columnCount(const QModelIndex&) const { return 5; }
+  virtual int columnCount(const QModelIndex&) const { return 6; }
 
 public slots:
   void on_changeFont(const QFont&);

--- a/src/common.h
+++ b/src/common.h
@@ -136,8 +136,9 @@ namespace QGit {
 		GRAPH_COL   = 0,
 		ANN_ID_COL  = 1,
 		LOG_COL     = 2,
-		AUTH_COL    = 3,
-		TIME_COL    = 4,
+		HASH_COL    = 3,
+		AUTH_COL    = 4,
+		TIME_COL    = 5,
 		COMMIT_COL  = 97, // dummy col used for sha searching
 		LOG_MSG_COL = 98, // dummy col used for log messages searching
 		SHA_MAP_COL = 99  // dummy col used when filter output is a set of matching sha
@@ -148,6 +149,7 @@ namespace QGit {
 	// default list view widths
 	const int DEF_GRAPH_COL_WIDTH = 80;
 	const int DEF_LOG_COL_WIDTH   = 500;
+	const int DEF_HASH_COL_WIDTH  = 90;
 	const int DEF_AUTH_COL_WIDTH  = 230;
 	const int DEF_TIME_COL_WIDTH  = 160;
 
@@ -314,6 +316,7 @@ public:
 	const ShaString parent(int idx) const;
 	const QStringList parents() const;
 	const ShaString sha() const { return ShaString(ba.constData() + shaStart); }
+	const QString shortHash(int len) const { return midSha(shaStart, len); }
 	const QString committer() const { setup(); return mid(comStart, autStart - comStart - 1); }
 	const QString author() const { setup(); return mid(autStart, autDateStart - autStart - 1); }
 	const QString authorDate() const { setup(); return mid(autDateStart, 10); }

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -64,6 +64,7 @@ Git::Git(QObject* p) : QObject(p) {
 	isStGIT = isGIT = loadingUnAppliedPatches = isTextHighlighterFound = false;
 	errorReportingEnabled = true; // report errors if run() fails
 	curDomain = NULL;
+	shortHashLen = shortHashLenDefault;
 	revData = NULL;
 	revsFiles.reserve(MAX_DICT_SIZE);
 }
@@ -274,12 +275,23 @@ const QStringList Git::getAllRefSha(uint mask) {
 	return shas;
 }
 
+/*
 const QString Git::refAsShortHash(SCRef sha)
 {
 	QString shortHash;
 	const bool success = run("git rev-parse --short " + sha, &shortHash);
 	// Fall back to input hash `sha` if rev-parse fails
 	return success ? shortHash : sha;
+}
+*/
+
+int Git::getShortHashLength()
+{
+	int len = 0;
+	QString shortHash;
+	if (run("git rev-parse --short HEAD", &shortHash))
+		len = shortHash.trimmed().size();   // Result contains a newline.
+	return (len > shortHashLenDefault) ? len : shortHashLenDefault;
 }
 
 const QString Git::getRefSha(SCRef refName, RefType type, bool askGit) {
@@ -2331,6 +2343,7 @@ bool Git::init(SCRef wd, bool askForRange, const QStringList* passedArgs, bool o
                         }
                 }
                 init2();
+                shortHashLen = getShortHashLength();
                 setThrowOnStop(false);
                 return true;
 

--- a/src/git.h
+++ b/src/git.h
@@ -35,6 +35,8 @@ public:
         static const bool optAmend       = true; //CT TODO enum
         static const bool optOnlyInIndex = true; //CT TODO private, enum
 
+	static const int shortHashLenDefault = 7;
+
 	enum RefType {
 		TAG        = 1,
 		BRANCH     = 2,
@@ -110,12 +112,13 @@ public:
 	uint checkRef(const ShaString& sha, uint mask = ANY_REF) const;
 	uint checkRef(SCRef sha, uint mask = ANY_REF) const;
 	const QString getRevInfo(SCRef sha);
+	int getShortHashLength();
 	const QString getRefSha(SCRef refName, RefType type = ANY_REF, bool askGit = true);
 	const QStringList getRefNames(SCRef sha, uint mask = ANY_REF) const;
 	const QStringList getAllRefNames(uint mask, bool onlyLoaded);
 	const QStringList getAllRefSha(uint mask);
 	const QStringList sortShaListByIndex(SCList shaList);
-	const QString refAsShortHash(SCRef sha);
+	//const QString refAsShortHash(SCRef sha);
 	void getWorkDirFiles(SList files, SList dirs, RevFile::StatusFlag status);
 	QTextCodec* getTextCodec(bool* isGitArchive);
 	bool formatPatch(SCList shaList, SCRef dirPath, SCRef remoteDir = "");
@@ -136,6 +139,7 @@ public:
 
 		return dirNamesVec[rf.dirAt(i)] + fileNamesVec[rf.nameAt(i)];
 	}
+	int shortHashLength() const { return shortHashLen; }
 	void setCurContext(Domain* d) { curDomain = d; }
 	Domain* curContext() const { return curDomain; }
 
@@ -277,6 +281,7 @@ private:
 	bool loadingUnAppliedPatches;
 	bool fileCacheAccessed;
 	int patchesStillToFind;
+	int shortHashLen;
 	QString firstNonStGitPatch;
 	RevFileMap revsFiles;
 	QVector<QByteArray> revsFilesShaBackupBuf;

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -105,6 +105,7 @@ void ListView::setupGeometry() {
 	hv->setSectionResizeMode(ANN_ID_COL, QHeaderView::ResizeToContents);
 	hv->resizeSection(GRAPH_COL, DEF_GRAPH_COL_WIDTH);
 	hv->resizeSection(LOG_COL, DEF_LOG_COL_WIDTH);
+	hv->resizeSection(HASH_COL, DEF_HASH_COL_WIDTH);
 	hv->resizeSection(AUTH_COL, DEF_AUTH_COL_WIDTH);
 	hv->resizeSection(TIME_COL, DEF_TIME_COL_WIDTH);
 

--- a/src/revsview.cpp
+++ b/src/revsview.cpp
@@ -323,7 +323,7 @@ void RevsView::updateLineEditSHA(bool clear) {
 
 	else if (l->text() != st.sha()) {
 		auto hash = QGit::testFlag(QGit::ENABLE_SHORTREF_F)
-			? git->refAsShortHash(st.sha())
+			? st.sha().left(git->shortHashLength())
 			: st.sha();
 
 		if (l->text().isEmpty())


### PR DESCRIPTION
This is a basic implementation for issue #118.  The hash size is hardcoded to show 8 characters.