### PR TITLE
Amend installation target for MacOS and Linux in the documentation.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -57,8 +57,8 @@ To compile, install and start qgit:
     also create a a desktop icon linked to 'start_qgit.bat' and double
     click on it.
 
-Installation directory is $HOME/bin under Linux and the directory of git
-exe files under Windows.
+Installation directory is `~/bin` under MacOS, `QT_INSTALL_BINS` (location of
+Qt binaries) under Linux and the directory of git exe files under Windows.
 
 You need to run 'qmake qgit.pro' only the first time to generate Makefile
 files, then you simply call 'make' and  'make install'. You may need to


### PR DESCRIPTION
According to [src/src.pro#L45](https://github.com/SubOptimal/qgit/blob/d1771ba32c5468afee623f0389279a8b66efa854/src/src.pro#L45) the installation directory on Linux is not `$HOME/bin` but rather `QT_INSTALL_BINS`.

The installation directory `~/bin` is used only on MacOS.