### PR TITLE
Reduce compilation warnings

### DIFF
--- a/src/FileHistory.cc
+++ b/src/FileHistory.cc
@@ -204,7 +204,7 @@ QModelIndex FileHistory::index(int row, int column, const QModelIndex&) const {
   if (row < 0 || row >= rowCnt)
     return QModelIndex();
 
-  return createIndex(row, column, (void*)0);
+  return createIndex(row, column, nullptr);
 }
 
 QModelIndex FileHistory::parent(const QModelIndex&) const {

--- a/src/FileHistory.cc
+++ b/src/FileHistory.cc
@@ -213,12 +213,12 @@ QModelIndex FileHistory::parent(const QModelIndex&) const {
   return no_parent;
 }
 
-const QString FileHistory::timeDiff(unsigned long secs) const {
+const QString FileHistory::timeDiff(unsigned long s) const {
 
-  ulong days  =  secs / (3600 * 24);
-  ulong hours = (secs - days * 3600 * 24) / 3600;
-  ulong min   = (secs - days * 3600 * 24 - hours * 3600) / 60;
-  ulong sec   =  secs - days * 3600 * 24 - hours * 3600 - min * 60;
+  ulong days  =  s / (3600 * 24);
+  ulong hours = (s - days * 3600 * 24) / 3600;
+  ulong min   = (s - days * 3600 * 24 - hours * 3600) / 60;
+  ulong sec   =  s - days * 3600 * 24 - hours * 3600 - min * 60;
   QString tmp;
   if (days > 0)
     tmp.append(QString::number(days) + "d ");

--- a/src/FileHistory.h
+++ b/src/FileHistory.h
@@ -32,14 +32,14 @@ public:
   void setEarlyOutputState(bool b = true) { earlyOutputCnt = (b ? earlyOutputCntBase : -1); }
   void setAnnIdValid(bool b = true) { annIdValid = b; }
 
-  virtual QVariant data(const QModelIndex &index, int role) const;
-  virtual Qt::ItemFlags flags(const QModelIndex& index) const;
-  virtual QVariant headerData(int s, Qt::Orientation o, int role = Qt::DisplayRole) const;
-  virtual QModelIndex index(int r, int c, const QModelIndex& par = QModelIndex()) const;
-  virtual QModelIndex parent(const QModelIndex& index) const;
-  virtual int rowCount(const QModelIndex& par = QModelIndex()) const;
-  virtual bool hasChildren(const QModelIndex& par = QModelIndex()) const;
-  virtual int columnCount(const QModelIndex&) const { return 6; }
+  virtual QVariant data(const QModelIndex &index, int role) const override;
+  virtual Qt::ItemFlags flags(const QModelIndex& index) const override;
+  virtual QVariant headerData(int s, Qt::Orientation o, int role = Qt::DisplayRole) const override;
+  virtual QModelIndex index(int r, int c, const QModelIndex& par = QModelIndex()) const override;
+  virtual QModelIndex parent(const QModelIndex& index) const override;
+  virtual int rowCount(const QModelIndex& par = QModelIndex()) const override;
+  virtual bool hasChildren(const QModelIndex& par = QModelIndex()) const override;
+  virtual int columnCount(const QModelIndex&) const override { return 6; }
 
 public slots:
   void on_changeFont(const QFont&);

--- a/src/annotate.cpp
+++ b/src/annotate.cpp
@@ -165,10 +165,10 @@ void Annotate::doAnnotate(const ShaString& ss) {
 	int parentNum = 1;
 	while (it != parents.constEnd()) {
 
-		FileAnnotation* pa = getFileAnnotation(*it);
-		const QString& diff(getPatch(sha, parentNum++));
+		pa = getFileAnnotation(*it);
+		const QString& diff2(getPatch(sha, parentNum++));
 		QStringList tmpAnn;
-		setAnnotation(diff, "Merge", pa->lines, tmpAnn);
+		setAnnotation(diff2, "Merge", pa->lines, tmpAnn);
 
 		// the two annotations must be of the same length
 		if (fa->lines.count() != tmpAnn.count()) {
@@ -214,7 +214,7 @@ void Annotate::setInitialAnnotation(SCRef fileSha, FileAnnotation* fa) {
 		fa->lines.append(empty);
 }
 
-const QString Annotate::setupAuthor(SCRef origAuthor, int annId) {
+const QString Annotate::setupAuthor(SCRef origAuthor, int id) {
 
 	QString tmp(origAuthor.section('<', 0, 0).trimmed()); // strip e-mail address
 	if (tmp.isEmpty()) { // probably only e-mail
@@ -232,7 +232,7 @@ const QString Annotate::setupAuthor(SCRef origAuthor, int annId) {
 
 		tmp.truncate(MAX_AUTHOR_LEN);
 	}
-	return QString("%1.%2").arg(annId, annNumLen).arg(tmp);
+	return QString("%1.%2").arg(id, annNumLen).arg(tmp);
 }
 
 void Annotate::unify(SList dst, SCList src) {
@@ -786,23 +786,23 @@ const QString Annotate::computeRanges(SCRef sha, int paraFrom, int paraTo, SCRef
 
 	for ( ; shaIdx >= 0; shaIdx--) {
 
-		SCRef sha(histRevOrder[shaIdx]);
+		SCRef sha2(histRevOrder[shaIdx]);
 
-		if (!ranges.contains(sha)) {
+		if (!ranges.contains(sha2)) {
 
-			curRev = git->revLookup(sha, fh);
+			curRev = git->revLookup(sha2, fh);
 
 			if (curRev->parentsCount() == 0) {
 				// the start of an independent branch is found in this case
 				// insert an empty range, the whole branch will be ignored.
 				// Merge of outside branches are very rare so this solution
 				// seems enough if we don't want to dive in (useless) complications.
-				ranges.insert(sha, RangeInfo());
+				ranges.insert(sha2, RangeInfo());
 				continue;
 			}
-			const QString& diff(getPatch(sha));
+			const QString& diff(getPatch(sha2));
 			if (diff.isEmpty()) {
-				dbp("ASSERT in rangeFilter 2: diff for %1 not found", sha);
+				dbp("ASSERT in rangeFilter 2: diff for %1 not found", sha2);
 				return "";
 			}
 			QString parSha(curRev->parent(0));
@@ -817,9 +817,9 @@ const QString Annotate::computeRanges(SCRef sha, int paraFrom, int paraTo, SCRef
 			}
 			RangeInfo r(ranges[parSha]);
 			updateRange(&r, diff, false);
-			ranges.insert(sha, r);
+			ranges.insert(sha2, r);
 
-			if (sha == target) // stop now, no need to continue
+			if (sha2 == target) // stop now, no need to continue
 				return ancestor;
 		}
 	}

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -38,14 +38,14 @@ bool Cache::save(const QString& gitDir, const RevFileMap& rf,
 	QDataStream stream(&data, QIODevice::WriteOnly);
 
 	// Write a header with a "magic number" and a version
-	stream << (quint32)C_MAGIC;
-	stream << (qint32)C_VERSION;
+	stream << static_cast<quint32>(C_MAGIC);
+	stream << static_cast<qint32>(C_VERSION);
 
-	stream << (qint32)dirs.count();
+	stream << static_cast<qint32>(dirs.count());
 	for (int i = 0; i < dirs.count(); ++i)
 		stream << dirs.at(i);
 
-	stream << (qint32)files.count();
+	stream << static_cast<qint32>(files.count());
 	for (int i = 0; i < files.count(); ++i)
 		stream << files.at(i);
 
@@ -83,7 +83,7 @@ bool Cache::save(const QString& gitDir, const RevFileMap& rf,
 		}
 	}
 	buf.resize(newSize);
-	stream << (qint32)newSize;
+	stream << static_cast<qint32>(newSize);
 	stream << buf;
 
 	for (int i = 0; i < v.size(); ++i)

--- a/src/commitimpl.h
+++ b/src/commitimpl.h
@@ -21,7 +21,7 @@ signals:
 	void changesCommitted(bool);
 
 public slots:
-	virtual void closeEvent(QCloseEvent*);
+	virtual void closeEvent(QCloseEvent*) override;
 	void pushButtonCommit_clicked();
 	void pushButtonAmend_clicked();
 	void pushButtonCancel_clicked();
@@ -43,7 +43,7 @@ private:
 	bool checkPatchName(QString& patchName);
 	bool checkConfirm(SCRef msg, SCRef patchName, SCList selFiles, bool amend);
 	void computePosition(int &col_pos, int &line_pos);
-    bool eventFilter(QObject* obj, QEvent* event);
+	bool eventFilter(QObject* obj, QEvent* event) override;
 
 	Git* git;
 	QString origMsg;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -217,19 +217,19 @@ const RevFile& RevFile::operator>>(QDataStream& stream) const {
 
         // skip common case of only modified files
         bool isEmpty = onlyModified;
-        stream << (quint32)isEmpty;
+        stream << static_cast<quint32>(isEmpty);
         if (!isEmpty)
                 stream << status;
 
         // skip common case of just one parent
         isEmpty = (mergeParent.isEmpty() || mergeParent.last() == 1);
-        stream << (quint32)isEmpty;
+        stream << static_cast<quint32>(isEmpty);
         if (!isEmpty)
                 stream << mergeParent;
 
         // skip common case of no rename/copies
         isEmpty = extStatus.isEmpty();
-        stream << (quint32)isEmpty;
+        stream << static_cast<quint32>(isEmpty);
         if (!isEmpty)
                 stream << extStatus;
 
@@ -247,17 +247,17 @@ RevFile& RevFile::operator<<(QDataStream& stream) {
         quint32 tmp;
 
         stream >> tmp;
-        onlyModified = (bool)tmp;
+        onlyModified = static_cast<bool>(tmp);
         if (!onlyModified)
                 stream >> status;
 
         stream >> tmp;
-        isEmpty = (bool)tmp;
+        isEmpty = static_cast<bool>(tmp);
         if (!isEmpty)
                 stream >> mergeParent;
 
         stream >> tmp;
-        isEmpty = (bool)tmp;
+        isEmpty = static_cast<bool>(tmp);
         if (!isEmpty)
                 stream >> extStatus;
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -11,18 +11,18 @@
 #include <QTextDocument>
 #include "common.h"
 
-const QString Rev::mid(int start, int len) const {
+const QString Rev::mid(int from, int len) const {
 
         // warning no sanity check is done on arguments
         const char* data = ba.constData();
-        return QString::fromLocal8Bit(data + start, len);
+        return QString::fromLocal8Bit(data + from, len);
 }
 
-const QString Rev::midSha(int start, int len) const {
+const QString Rev::midSha(int from, int len) const {
 
         // warning no sanity check is done on arguments
         const char* data = ba.constData();
-        return QString::fromLatin1(data + start, len); // faster then formAscii
+        return QString::fromLatin1(data + from, len); // faster then formAscii
 }
 
 const ShaString Rev::parent(int idx) const {

--- a/src/common.h
+++ b/src/common.h
@@ -445,14 +445,14 @@ typedef QHash<ShaString, FileAnnotation> AnnotateHistory;
 
 class BaseEvent: public QEvent {
 public:
-	BaseEvent(SCRef d, int id) : QEvent((QEvent::Type)id), payLoad(d) {}
+	BaseEvent(SCRef ref, int id) : QEvent((QEvent::Type)id), payLoad(ref) {}
 	const QString myData() const { return payLoad; }
 private:
 	const QString payLoad; // passed by copy
 };
 
 #define DEF_EVENT(X, T) class X : public BaseEvent { public:        \
-                        explicit X (SCRef d) : BaseEvent(d, T) {} }
+                        explicit X (SCRef ref) : BaseEvent(ref, T) {} }
 
 DEF_EVENT(MessageEvent, QGit::MSG_EV);
 DEF_EVENT(AnnotateProgressEvent, QGit::ANN_PRG_EV);

--- a/src/common.h
+++ b/src/common.h
@@ -34,7 +34,7 @@
 template<typename T> inline const QString _valueOf(const T& x) { return QVariant(x).toString(); }
 template<> inline const QString _valueOf(const QStringList& x) { return x.join(" "); }
 inline const QString& _valueOf(const QString& x) { return x; }
-inline const QString  _valueOf(size_t x) { return QString::number((uint)x); }
+inline const QString  _valueOf(size_t x) { return QString::number(static_cast<uint>(x)); }
 
 // some debug macros
 #define constlatin(x) (_valueOf(x).toLatin1().constData())
@@ -403,15 +403,15 @@ public:
 	 */
 	QByteArray pathsIdx;
 
-	int dirAt(uint idx) const { return ((const int*)pathsIdx.constData())[idx]; }
-	int nameAt(uint idx) const { return ((const int*)pathsIdx.constData())[count() + idx]; }
+	int dirAt(uint idx) const { return reinterpret_cast<const int *>(pathsIdx.constData())[idx]; }
+	int nameAt(uint idx) const { return reinterpret_cast<const int *>(pathsIdx.constData())[count() + idx]; }
 
 	QVector<int> mergeParent;
 
 	// helper functions
 	int count() const {
 
-		return pathsIdx.size() / ((int)sizeof(int) * 2);
+		return pathsIdx.size() / (sizeof(int) * 2);
 	}
 	bool statusCmp(int idx, StatusFlag sf) const {
 
@@ -445,7 +445,7 @@ typedef QHash<ShaString, FileAnnotation> AnnotateHistory;
 
 class BaseEvent: public QEvent {
 public:
-	BaseEvent(SCRef ref, int id) : QEvent((QEvent::Type)id), payLoad(ref) {}
+	BaseEvent(SCRef ref, int id) : QEvent(static_cast<QEvent::Type>(id)), payLoad(ref) {}
 	const QString myData() const { return payLoad; }
 private:
 	const QString payLoad; // passed by copy

--- a/src/consoleimpl.cpp
+++ b/src/consoleimpl.cpp
@@ -78,10 +78,10 @@ bool ConsoleImpl::start(const QString& cmd) {
 	return !proc.isNull();
 }
 
-void ConsoleImpl::procReadyRead(const QByteArray& data) {
+void ConsoleImpl::procReadyRead(const QByteArray& read) {
 
 	QString newParagraph;
-	if (QGit::stripPartialParaghraps(data, &newParagraph, &inpBuf))
+	if (QGit::stripPartialParaghraps(read, &newParagraph, &inpBuf))
 		// QTextEdit::append() adds a new paragraph,
 		// i.e. inserts a LF if not already present.
 		textEditOutput->append(newParagraph);

--- a/src/consoleimpl.h
+++ b/src/consoleimpl.h
@@ -31,7 +31,7 @@ public slots:
 	void procFinished();
 
 protected slots:
-	virtual void closeEvent(QCloseEvent* ce);
+	virtual void closeEvent(QCloseEvent* ce) override;
 	void pushButtonTerminate_clicked();
 	void pushButtonOk_clicked();
 

--- a/src/customactionimpl.cpp
+++ b/src/customactionimpl.cpp
@@ -42,8 +42,7 @@ void CustomActionImpl::loadAction(const QString& name) {
 	const QString flags(ACT_GROUP_KEY + name + ACT_FLAGS_KEY);
 	checkBoxRefreshAfterAction->setChecked(testFlag(ACT_REFRESH_F, flags));
 	QSettings set;
-	const QString& data(set.value(ACT_GROUP_KEY + name + ACT_TEXT_KEY, "").toString());
-	textEditAction->setPlainText(data);
+	textEditAction->setPlainText(set.value(ACT_GROUP_KEY + name + ACT_TEXT_KEY, "").toString());
 }
 
 void CustomActionImpl::removeAction(const QString& name) {

--- a/src/customactionimpl.h
+++ b/src/customactionimpl.h
@@ -20,7 +20,7 @@ signals:
 	void listChanged(const QStringList&);
 
 protected slots:
-	virtual void closeEvent(QCloseEvent*);
+	virtual void closeEvent(QCloseEvent*) override;
 	void listWidgetNames_currentItemChanged(QListWidgetItem*, QListWidgetItem*);
 	void pushButtonNew_clicked();
 	void pushButtonRename_clicked();

--- a/src/dataloader.cpp
+++ b/src/dataloader.cpp
@@ -168,7 +168,7 @@ void DataLoader::addSplittedChunks(const QByteArray* hc) {
 	}
 	// do not assume we have only one chunk in hc
 	int ofs = 0;
-	while (ofs != -1 && ofs != (int)hc->size())
+	while (ofs != -1 && ofs != static_cast<int>(hc->size()))
 		ofs = git->addChunk(fh, *hc, ofs);
 }
 

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -217,13 +217,13 @@ bool Domain::event(QEvent* e) {
 		fromMaster = true;
 		// fall through
 	case UPD_DM_EV:
-		update(fromMaster, ((UpdateDomainEvent*)e)->isForced());
+		update(fromMaster, static_cast<UpdateDomainEvent *>(e)->isForced());
 		break;
 	case MSG_EV:
 		if (!busy && !st.requestPending())
-			QApplication::postEvent(m(), new MessageEvent(((MessageEvent*)e)->myData()));
+			QApplication::postEvent(m(), new MessageEvent(static_cast<MessageEvent *>(e)->myData()));
 		else // waiting for the end of updating
-			statusBarRequest = ((MessageEvent*)e)->myData();
+			statusBarRequest = static_cast<MessageEvent *>(e)->myData();
 		break;
 	default:
 		break;
@@ -275,7 +275,9 @@ void Domain::update(bool fromMaster, bool force) {
 		busy = false;
 		if (git->curContext() != this)
 			qDebug("ASSERT in Domain::update, context is %p "
-			       "instead of %p", (void*)git->curContext(), (void*)this);
+			       "instead of %p",
+			       static_cast<void *>(git->curContext()),
+			       static_cast<void *>(this));
 
 		git->setCurContext(NULL);
 		git->setThrowOnStop(false);

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -59,6 +59,12 @@ StateInfo& StateInfo::operator=(const StateInfo& newState) {
 	return *this;
 }
 
+StateInfo::StateInfo(const StateInfo& newState) {
+
+	isLocked = false;
+	curS = newState.curS; // prevS is mot modified to allow a rollback
+}
+
 bool StateInfo::operator==(const StateInfo& newState) const {
 
 	if (&newState == this)

--- a/src/domain.h
+++ b/src/domain.h
@@ -131,7 +131,7 @@ protected slots:
 
 protected:
 	virtual void clear(bool complete = true);
-	virtual bool event(QEvent* e);
+	virtual bool event(QEvent* e) override;
 	virtual bool doUpdate(bool force) = 0;
 	void linkDomain(Domain* d);
 	void unlinkDomain(Domain* d);

--- a/src/domain.h
+++ b/src/domain.h
@@ -24,8 +24,8 @@ class MainImpl;
 class UpdateDomainEvent : public QEvent {
 public:
 	explicit UpdateDomainEvent(bool fromMaster, bool force = false)
-	: QEvent(fromMaster ? (QEvent::Type)QGit::UPD_DM_MST_EV
-	                    : (QEvent::Type)QGit::UPD_DM_EV), f(force) {}
+		: QEvent(fromMaster ? static_cast<QEvent::Type>(QGit::UPD_DM_MST_EV)
+			            : static_cast<QEvent::Type>(QGit::UPD_DM_EV)), f(force) {}
 	bool isForced() const { return f; }
 private:
 	bool f;

--- a/src/domain.h
+++ b/src/domain.h
@@ -35,6 +35,7 @@ class StateInfo {
 public:
 	StateInfo() { clear(); }
 	StateInfo& operator=(const StateInfo& newState);
+	StateInfo(const StateInfo& newState);
 	bool operator==(const StateInfo& newState) const;
 	bool operator!=(const StateInfo& newState) const;
 	void clear();

--- a/src/filecontent.cpp
+++ b/src/filecontent.cpp
@@ -601,8 +601,8 @@ void FileContent::setAnnList() {
 	QBrush back(Qt::lightGray);
 	QFont f(listWidgetAnn->font());
 	f.setBold(true);
-	FOREACH (QVector<int>, it, curIdLines) {
-		QListWidgetItem* item = listWidgetAnn->item(*it);
+	FOREACH (QVector<int>, it2, curIdLines) {
+		QListWidgetItem* item = listWidgetAnn->item(*it2);
 		item->setForeground(fore);
 		item->setBackground(back);
 		item->setFont(f);

--- a/src/filecontent.cpp
+++ b/src/filecontent.cpp
@@ -24,7 +24,7 @@
 class FileHighlighter : public QSyntaxHighlighter {
 public:
 	FileHighlighter(FileContent* fc) : QSyntaxHighlighter(fc), f(fc) {}
-	virtual void highlightBlock(const QString& p) {
+	virtual void highlightBlock(const QString& p) override {
 
 		// state is used to count lines, starting from 0
 		if (currentBlockState() == -1) // only once

--- a/src/filecontent.h
+++ b/src/filecontent.h
@@ -56,7 +56,7 @@ public slots:
 	void typeWriterFontChanged();
 
 protected:
-	virtual void resizeEvent(QResizeEvent* e);
+	virtual void resizeEvent(QResizeEvent* e) override;
 
 private slots:
 	void on_list_doubleClicked(QListWidgetItem*);

--- a/src/filelist.h
+++ b/src/filelist.h
@@ -29,8 +29,8 @@ public slots:
 	void on_changeFont(const QFont& f);
 
 protected:
-	virtual void focusInEvent(QFocusEvent*);
-	virtual void mouseMoveEvent(QMouseEvent*);
+	virtual void focusInEvent(QFocusEvent*) override;
+	virtual void mouseMoveEvent(QMouseEvent*) override;
 	bool startDragging(QMouseEvent *e);
 
 private slots:

--- a/src/fileview.h
+++ b/src/fileview.h
@@ -21,7 +21,7 @@ public:
 	FileView() {}
 	FileView(MainImpl* m, Git* git);
 	~FileView();
-	virtual void clear(bool complete = true);
+	virtual void clear(bool complete = true) override;
 	void append(SCRef data);
 	void historyReady();
 	void updateHistViewer(SCRef revSha, SCRef fileName, bool fromUpstream = true);
@@ -44,9 +44,9 @@ public slots:
 	void on_revIdSelected(int);
 
 protected:
-	virtual bool doUpdate(bool force);
-	virtual bool isMatch(SCRef sha);
-	virtual bool eventFilter(QObject *obj, QEvent *e);
+	virtual bool doUpdate(bool force) override;
+	virtual bool isMatch(SCRef sha) override;
+	virtual bool eventFilter(QObject *obj, QEvent *e) override;
 
 private:
 	friend class MainImpl;

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -1705,7 +1705,7 @@ const QStringList Git::getArgs(bool* quit, bool repoChanged) {
         }
         if (!startup || args.isEmpty()) { // need to retrieve args
                 if (testFlag(RANGE_SELECT_F)) { // open range dialog
-                        RangeSelectImpl rs((QWidget*)parent(), &args, repoChanged, this);
+                        RangeSelectImpl rs(qobject_cast<QWidget *>(parent()), &args, repoChanged, this);
                         *quit = (rs.exec() == QDialog::Rejected); // modal execution
                         if (*quit)
                             return QStringList();
@@ -2430,7 +2430,7 @@ void Git::on_loaded(FileHistory* fh, ulong byteSize, int loadTime,
                         fh->loadTime += loadTime;
 
                         ulong kb = byteSize / 1024;
-                        double mbs = (double)byteSize / fh->loadTime / 1000;
+                        double mbs = static_cast<double>(byteSize) / fh->loadTime / 1000;
                         QString tmp;
                         tmp.asprintf("Loaded %i revisions  (%li KB),   "
                                      "time elapsed: %i ms  (%.2f MB/s)",
@@ -2888,7 +2888,7 @@ void Git::flushFileNames(FileNamesLoader& fl) {
         b.clear();
         b.resize(2 * dirs.size() * static_cast<int>(sizeof(int)));
 
-        int* d = (int*)(b.data());
+        int* d = reinterpret_cast<int *>(b.data());
 
         for (int i = 0; i < dirs.size(); i++) {
 
@@ -2952,7 +2952,7 @@ void Git::updateDescMap(const Rev* r,uint idx, QHash<QPair<uint, uint>, bool>& d
 
                         for (int y = 0; y < dvv.count(); y++) {
 
-                                uint v = (uint)dvv[y];
+                                uint v = static_cast<uint>(dvv[y]);
                                 QPair<uint, uint> key = qMakePair(idx, v);
                                 QPair<uint, uint> keyN = qMakePair(v, idx);
                                 dm.insert(key, true);
@@ -3018,7 +3018,7 @@ void Git::mergeNearTags(bool down, Rev* p, const Rev* r, const QHash<QPair<uint,
                                 add = false;
                                 break;
                         }
-                        QPair<uint, uint> key = qMakePair((uint)src2[s2], (uint)src1[s1]);
+                        QPair<uint, uint> key = qMakePair(static_cast<uint>(src2[s2]), static_cast<uint>(src1[s1]));
 
                         if (!dm.contains(key)) { // could be empty if all tags are independent
                                 add = true; // could be an independent path

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -630,8 +630,8 @@ const QStringList Git::getChildren(SCRef parent) {
         // reorder children by loading order
         QStringList::iterator itC(children.begin());
         for ( ; itC != children.end(); ++itC) {
-		const Rev* r = revLookup(*itC);
-		(*itC).prepend(QString("%1 ").arg(r->orderIdx, 6));
+		const Rev* rev = revLookup(*itC);
+		(*itC).prepend(QString("%1 ").arg(rev->orderIdx, 6));
 	}
         children.sort();
         for (itC = children.begin(); itC != children.end(); ++itC)
@@ -926,13 +926,13 @@ const QStringList Git::getDescendantBranches(SCRef sha, bool shaOnly) {
 
 	for (int i = 0; i < nr.count(); i++) {
 
-		const ShaString& sha = revData->revOrder[nr[i]];
+		const ShaString& sha2 = revData->revOrder[nr[i]];
 		if (shaOnly) {
-			tl.append(sha);
+			tl.append(sha2);
 			continue;
 		}
-		SCRef cap = " (" + sha + ") ";
-		RefMap::const_iterator it(refsShaMap.find(sha));
+		SCRef cap = " (" + sha2 + ") ";
+		RefMap::const_iterator it(refsShaMap.find(sha2));
 		if (it == refsShaMap.constEnd())
 			continue;
 
@@ -961,9 +961,9 @@ const QStringList Git::getNearTags(bool goDown, SCRef sha) {
 
 	for (int i = 0; i < nr.count(); i++) {
 
-		const ShaString& sha = revData->revOrder[nr[i]];
-		SCRef cap = " (" + sha + ")";
-		RefMap::const_iterator it(refsShaMap.find(sha));
+		const ShaString& sha2 = revData->revOrder[nr[i]];
+		SCRef cap = " (" + sha2 + ")";
+		RefMap::const_iterator it(refsShaMap.find(sha2));
 		if (it != refsShaMap.constEnd())
 			tl.append((*it).tags.join(cap).append(cap));
 	}
@@ -2912,19 +2912,19 @@ void Git::appendFileName(RevFile& rf, SCRef name, FileNamesLoader& fl) {
 
         QHash<QString, int>::const_iterator it(dirNamesMap.constFind(dr));
         if (it == dirNamesMap.constEnd()) {
-                int idx = dirNamesVec.count();
-                dirNamesMap.insert(dr, idx);
+                int num = dirNamesVec.count();
+                dirNamesMap.insert(dr, num);
                 dirNamesVec.append(dr);
-                fl.rfDirs.append(idx);
+                fl.rfDirs.append(num);
         } else
                 fl.rfDirs.append(*it);
 
         it = fileNamesMap.constFind(nm);
         if (it == fileNamesMap.constEnd()) {
-                int idx = fileNamesVec.count();
-                fileNamesMap.insert(nm, idx);
+                int num = fileNamesVec.count();
+                fileNamesMap.insert(nm, num);
                 fileNamesVec.append(nm);
-                fl.rfNames.append(idx);
+                fl.rfNames.append(num);
         } else
                 fl.rfNames.append(*it);
 }

--- a/src/inputdialog.cpp
+++ b/src/inputdialog.cpp
@@ -44,8 +44,8 @@ public:
 	    , allowEmpty(allowEmpty)
 	{}
 
-	void fixup(QString& input) const;
-	State validate(QString & input, int & pos) const;
+	void fixup(QString& input) const override;
+	State validate(QString & input, int & pos) const override;
 private:
 	const QRegExp invalid;
 	bool allowEmpty;

--- a/src/inputdialog.cpp
+++ b/src/inputdialog.cpp
@@ -38,10 +38,10 @@ QStringList parseStringList(const QString &value, const InputDialog::VariableMap
 
 class RefNameValidator : public QValidator {
 public:
-	RefNameValidator(bool allowEmpty=false, QObject *parent=0)
+	RefNameValidator(bool allowEmptyP=false, QObject *parent=0)
 	    : QValidator(parent)
 	    , invalid("[ ~^:\?*[]")
-	    , allowEmpty(allowEmpty)
+	    , allowEmpty(allowEmptyP)
 	{}
 
 	void fixup(QString& input) const override;
@@ -81,10 +81,10 @@ QValidator::State RefNameValidator::validate(QString &input, int &pos) const
 }
 
 
-InputDialog::InputDialog(const QString &cmd, const VariableMap &variables,
+InputDialog::InputDialog(const QString &c, const VariableMap &variables,
                          const QString &title, QWidget *parent, Qt::WindowFlags f)
     : QDialog(parent, f)
-    , cmd(cmd)
+    , cmd(c)
 {
 	this->setWindowTitle(title);
 	QGridLayout *layout = new QGridLayout(this);

--- a/src/lanes.cpp
+++ b/src/lanes.cpp
@@ -159,16 +159,16 @@ void Lanes::setMerge(const QStringList& parents) {
 
 	for (int i = rangeStart + 1; i < rangeEnd; i++) {
 
-		int& t = typeVec[i];
+		int& type = typeVec[i];
 
-		if (t == NOT_ACTIVE)
-			t = CROSS;
+		if (type == NOT_ACTIVE)
+			type = CROSS;
 
-		else if (t == EMPTY)
-			t = CROSS_EMPTY;
+		else if (type == EMPTY)
+			type = CROSS_EMPTY;
 
-		else if (t == TAIL_R || t == TAIL_L)
-			t = TAIL;
+		else if (type == TAIL_R || type == TAIL_L)
+			type = TAIL;
 	}
 }
 

--- a/src/lanes.cpp
+++ b/src/lanes.cpp
@@ -282,7 +282,7 @@ int Lanes::findType(int type, int pos) {
 int Lanes::add(int type, const QString& next, int pos) {
 
 	// first check empty lanes starting from pos
-	if (pos < (int)typeVec.count()) {
+	if (pos < static_cast<int>(typeVec.count())) {
 		pos = findType(EMPTY, pos);
 		if (pos != -1) {
 			typeVec[pos] = type;

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -717,8 +717,8 @@ public:
 	void next();
 };
 
-RefNameIterator::RefNameIterator(const QString &sha, Git *git)
-    : git(git), sha(sha), cur_state(0), cur_branch(git->getCurrentBranchName())
+RefNameIterator::RefNameIterator(const QString &s, Git *g)
+    : git(g), sha(s), cur_state(0), cur_branch(git->getCurrentBranchName())
 {
 	ref_types = git->checkRef(sha);
 	if (ref_types == 0) {
@@ -990,20 +990,20 @@ void ListViewDelegate::paintGraphLane(QPainter* p, int type, int x1, int x2,
 }
 
 void ListViewDelegate::paintGraph(QPainter* p, const QStyleOptionViewItem& opt,
-                                  const QModelIndex& i) const {
+                                  const QModelIndex& idx) const {
 	static const QColor & baseColor = QPalette().color(QPalette::WindowText);
 	static const QColor colors[COLORS_NUM] = { baseColor, Qt::red, DARK_GREEN,
 	                                           Qt::blue, Qt::darkGray, BROWN,
 	                                           Qt::magenta, ORANGE };
 	if (opt.state & QStyle::State_Selected)
 		p->fillRect(opt.rect, opt.palette.highlight());
-	else if (i.row() & 1)
+	else if (idx.row() & 1)
 		p->fillRect(opt.rect, opt.palette.alternateBase());
 	else
 		p->fillRect(opt.rect, opt.palette.base());
 
 	FileHistory* fh;
-	const Rev* r = revLookup(i.row(), &fh);
+	const Rev* r = revLookup(idx. row(), &fh);
 	if (!r)
 		return;
 

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -752,7 +752,7 @@ void RefNameIterator::next()
 		case Git::TAG: cur_state = Git::REF; break;
 		default: cur_state = -1; // indicate end
 		}
-		ref_names = git->getRefNames(sha, (Git::RefType)cur_state);
+		ref_names = git->getRefNames(sha, static_cast<Git::RefType>(cur_state));
 		cur_name = ref_names.begin();
 	}
 }

--- a/src/listview.h
+++ b/src/listview.h
@@ -58,19 +58,19 @@ public slots:
 	void on_keyDown();
 
 protected:
-	virtual void mousePressEvent(QMouseEvent* e);
-	virtual void mouseMoveEvent(QMouseEvent* e);
-	virtual void mouseReleaseEvent(QMouseEvent* e);
-	virtual void dragEnterEvent(QDragEnterEvent* e);
-	virtual void dragMoveEvent(QDragMoveEvent* e);
-	virtual void dragLeaveEvent(QDragLeaveEvent* event);
-	virtual void dropEvent(QDropEvent* e);
+	virtual void mousePressEvent(QMouseEvent* e) override;
+	virtual void mouseMoveEvent(QMouseEvent* e) override;
+	virtual void mouseReleaseEvent(QMouseEvent* e) override;
+	virtual void dragEnterEvent(QDragEnterEvent* e) override;
+	virtual void dragMoveEvent(QDragMoveEvent* e) override;
+	virtual void dragLeaveEvent(QDragLeaveEvent* event) override;
+	virtual void dropEvent(QDropEvent* e) override;
 	void startDragging(QMouseEvent *e);
 	QPixmap pixmapFromSelection(const QStringList &revs, const QString &ref) const;
 
 private slots:
 	void on_customContextMenuRequested(const QPoint&);
-	virtual void currentChanged(const QModelIndex&, const QModelIndex&);
+	virtual void currentChanged(const QModelIndex&, const QModelIndex&) override;
 
 private:
 	void setupGeometry();
@@ -95,8 +95,8 @@ Q_OBJECT
 public:
 	ListViewDelegate(Git* git, ListViewProxy* lp, QObject* parent);
 
-	virtual void paint(QPainter* p, const QStyleOptionViewItem& o, const QModelIndex &i) const;
-	virtual QSize sizeHint(const QStyleOptionViewItem& o, const QModelIndex &i) const;
+	virtual void paint(QPainter* p, const QStyleOptionViewItem& o, const QModelIndex &i) const override;
+	virtual QSize sizeHint(const QStyleOptionViewItem& o, const QModelIndex &i) const override;
 	int laneWidth() const { return 3 * laneHeight / 4; }
 	void setLaneHeight(int h) { laneHeight = h; }
 
@@ -130,7 +130,7 @@ public:
 	bool isHighlighted(int row) const;
 
 protected:
-	virtual bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const;
+	virtual bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
 
 private:
 	bool isMatch(int row) const;

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -997,11 +997,11 @@ bool MainImpl::event(QEvent* e) {
 	SCRef data = de->myData();
 	bool ret = true;
 
-        switch ((EventType)e->type()) {
+        switch (static_cast<EventType>(e->type())) {
 	case ERROR_EV: {
 		QApplication::setOverrideCursor(QCursor(Qt::ArrowCursor));
 		EM_PROCESS_EVENTS;
-		MainExecErrorEvent* me = (MainExecErrorEvent*)e;
+		MainExecErrorEvent* me = static_cast<MainExecErrorEvent *>(e);
 		QString text("An error occurred while executing command:\n\n");
 		text.append(me->command() + "\n\n" + me->report());
 		QMessageBox::warning(this, "Error - QGit", text);

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -994,7 +994,7 @@ bool MainImpl::event(QEvent* e) {
 	if (!de)
 		return QWidget::event(e);
 
-	SCRef data = de->myData();
+	SCRef d = de->myData();
 	bool ret = true;
 
         switch (static_cast<EventType>(e->type())) {
@@ -1008,14 +1008,14 @@ bool MainImpl::event(QEvent* e) {
 		QApplication::restoreOverrideCursor(); }
 		break;
 	case MSG_EV:
-		statusBar()->showMessage(data);
+		statusBar()->showMessage(d);
 		break;
 	case POPUP_LIST_EV:
-		doContexPopup(data);
+		doContexPopup(d);
 		break;
 	case POPUP_FILE_EV:
 	case POPUP_TREE_EV:
-		doFileContexPopup(data, e->type());
+		doFileContexPopup(d, e->type());
 		break;
 	default:
 		dbp("ASSERT in MainImpl::event unhandled event %1", e->type());
@@ -1285,11 +1285,11 @@ void MainImpl::updateCommitMenu(bool isStGITStack) {
 void MainImpl::updateRecentRepoMenu(SCRef newEntry) {
 
 	// update menu of all windows
-	foreach (QWidget* widget, QApplication::topLevelWidgets()) {
+	foreach (QWidget* w, QApplication::topLevelWidgets()) {
 
-		MainImpl* w = dynamic_cast<MainImpl*>(widget);
-		if (w)
-			w->doUpdateRecentRepoMenu(newEntry);
+		MainImpl* wmi = qobject_cast<MainImpl *>(w);
+		if (wmi)
+			wmi->doUpdateRecentRepoMenu(newEntry);
 	}
 }
 
@@ -1475,19 +1475,16 @@ void MainImpl::ActSplitView_activated() {
 	Domain* t;
 	switch (currentTabType(&t)) {
 	case TAB_REV: {
-		RevsView* rv = static_cast<RevsView*>(t);
-		QWidget* w = rv->tab()->fileList;
+		QWidget* w = static_cast<RevsView*>(t)->tab()->fileList;
 		QSplitter* sp = static_cast<QSplitter*>(w->parent());
 		sp->setHidden(w->isVisible()); }
 		break;
 	case TAB_PATCH: {
-		PatchView* pv = static_cast<PatchView*>(t);
-		QWidget* w = pv->tab()->textBrowserDesc;
+		QWidget* w = static_cast<PatchView*>(t)->tab()->textBrowserDesc;
 		w->setHidden(w->isVisible()); }
 		break;
 	case TAB_FILE: {
-		FileView* fv = static_cast<FileView*>(t);
-		QWidget* w = fv->tab()->histListView;
+		QWidget* w = static_cast<FileView*>(t)->tab()->histListView;
 		w->setHidden(w->isVisible()); }
 		break;
 	default:
@@ -1500,8 +1497,7 @@ void MainImpl::ActToggleLogsDiff_activated() {
 
 	Domain* t;
 	if (currentTabType(&t) == TAB_REV) {
-		RevsView* rv = static_cast<RevsView*>(t);
-		rv->toggleDiffView();
+		static_cast<RevsView*>(t)->toggleDiffView();
 	}
 }
 
@@ -1702,11 +1698,11 @@ void MainImpl::ActCustomActionSetup_activated() {
 void MainImpl::customActionListChanged(const QStringList& list) {
 
 	// update menu of all windows
-	foreach (QWidget* widget, QApplication::topLevelWidgets()) {
+	foreach (QWidget* w, QApplication::topLevelWidgets()) {
 
-		MainImpl* w = dynamic_cast<MainImpl*>(widget);
-		if (w)
-			w->doUpdateCustomActionMenu(list);
+		MainImpl* wmi = qobject_cast<MainImpl*>(w);
+		if (wmi)
+			wmi->doUpdateCustomActionMenu(list);
 	}
 }
 

--- a/src/mainimpl.h
+++ b/src/mainimpl.h
@@ -75,7 +75,7 @@ private slots:
 	void shortCutActivated();
 
 protected:
-	virtual bool event(QEvent* e);
+	virtual bool event(QEvent* e) override;
 
 protected slots:
 	void initWithEventLoopActive();
@@ -134,12 +134,12 @@ protected slots:
 	void ActAbout_activated();
 	void ActHelp_activated();
 	void ActMarkDiffToSha_activated();
-	void closeEvent(QCloseEvent* ce);
+	void closeEvent(QCloseEvent* ce) override;
 
 private:
 	friend class setRepoDelayed;
 
-	virtual bool eventFilter(QObject* obj, QEvent* ev);
+	virtual bool eventFilter(QObject* obj, QEvent* ev) override;
 	void updateGlobalActions(bool b);
 	void updateRevVariables(SCRef sha);
 	void setupShortcuts();

--- a/src/myprocess.cpp
+++ b/src/myprocess.cpp
@@ -108,9 +108,9 @@ void MyProcess::sendErrorMsg(bool notStarted) {
 	QApplication::postEvent(guiObject, e);
 }
 
-bool MyProcess::launchMe(SCRef runCmd, SCRef buf) {
+bool MyProcess::launchMe(SCRef cmd, SCRef buf) {
 
-	arguments = splitArgList(runCmd);
+	arguments = splitArgList(cmd);
 	if (arguments.isEmpty())
 		return false;
 

--- a/src/patchcontent.cpp
+++ b/src/patchcontent.cpp
@@ -159,12 +159,12 @@ int PatchContent::topToLineNum() {
 	return cursorForPosition(QPoint(1, 1)).blockNumber();
 }
 
-bool PatchContent::centerTarget(SCRef target) {
+bool PatchContent::centerTarget(SCRef tgt) {
 
 	moveCursor(QTextCursor::Start);
 
 	// find() updates cursor position
-	if (!find(target, QTextDocument::FindCaseSensitively | QTextDocument::FindWholeWords))
+	if (!find(tgt, QTextDocument::FindCaseSensitively | QTextDocument::FindWholeWords))
 		return false;
 
 	// move to the beginning of the line
@@ -202,11 +202,11 @@ void PatchContent::centerMatch(int id) {
 //	                                     matches[id].paraTo, matches[id].indexTo);
 }
 
-void PatchContent::procReadyRead(const QByteArray& data) {
+void PatchContent::procReadyRead(const QByteArray& read) {
 
-	patchRowData.append(data);
+	patchRowData.append(read);
 	if (document()->isEmpty() && isVisible())
-		processData(data);
+		processData(read);
 }
 
 void PatchContent::typeWriterFontChanged() {

--- a/src/patchcontent.h
+++ b/src/patchcontent.h
@@ -21,7 +21,7 @@ class DiffHighlighter : public QSyntaxHighlighter {
 public:
 	DiffHighlighter(QTextEdit* p) : QSyntaxHighlighter(p), cl(0) {}
 	void setCombinedLength(uint c) { cl = c; }
-	virtual void highlightBlock(const QString& text);
+	virtual void highlightBlock(const QString& text) override;
 private:
 	uint cl;
 };

--- a/src/patchview.h
+++ b/src/patchview.h
@@ -18,7 +18,7 @@ public:
 	PatchView() {}
 	PatchView(MainImpl* mi, Git* g);
 	~PatchView();
-	void clear(bool complete = true);
+	void clear(bool complete = true) override;
 	Ui_TabPatch* tab() { return patchTab; }
 
 signals:
@@ -32,10 +32,10 @@ public slots:
 	void buttonFilterPatch_clicked();
 
 protected slots:
-	virtual void on_contextMenu(const QString&, int);
+	virtual void on_contextMenu(const QString&, int) override;
 
 protected:
-	virtual bool doUpdate(bool force);
+	virtual bool doUpdate(bool force) override;
 
 private:
 	void updatePatch();

--- a/src/revdesc.h
+++ b/src/revdesc.h
@@ -17,7 +17,7 @@ public:
 	void setup(Domain* dm) { d = dm; }
 
 protected:
-	virtual void contextMenuEvent(QContextMenuEvent* e);
+	virtual void contextMenuEvent(QContextMenuEvent* e) override;
 
 private slots:
 	void on_anchorClicked(const QUrl& link);

--- a/src/revsview.h
+++ b/src/revsview.h
@@ -22,7 +22,7 @@ Q_OBJECT
 public:
 	RevsView(MainImpl* parent, Git* git, bool isMain = false);
 	~RevsView();
-	void clear(bool complete);
+	void clear(bool complete) override;
 	void viewPatch(bool newTab);
 	void setEnabled(bool b);
 	void setTabLogDiffVisible(bool);
@@ -39,7 +39,7 @@ private slots:
 	void on_flagChanged(uint flag);
 
 protected:
-	virtual bool doUpdate(bool force);
+	virtual bool doUpdate(bool force) override;
 
 private:
 	friend class MainImpl;

--- a/src/smartbrowse.h
+++ b/src/smartbrowse.h
@@ -15,10 +15,10 @@ class SmartLabel : public QLabel {
 Q_OBJECT
 public:
 	SmartLabel(const QString& text, QWidget* par);
-	void paintEvent(QPaintEvent* event);
+	void paintEvent(QPaintEvent* event) override;
 
 protected:
-	virtual void contextMenuEvent(QContextMenuEvent* e);
+	virtual void contextMenuEvent(QContextMenuEvent* e) override;
 
 private slots:
 	void switchLinks();
@@ -30,7 +30,7 @@ public:
 	SmartBrowse(RevsView* par);
 
 protected:
-	bool eventFilter(QObject *obj, QEvent *event);
+	bool eventFilter(QObject *obj, QEvent *event) override;
 
 public slots:
 	void updateVisibility();

--- a/src/treeview.cpp
+++ b/src/treeview.cpp
@@ -66,7 +66,7 @@ void TreeView::setup(Domain* dm, Git* g) {
 void TreeView::on_currentItemChanged(QTreeWidgetItem* item, QTreeWidgetItem*) {
 
 	if (item) {
-		SCRef fn = ((FileItem*)item)->fullName();
+		SCRef fn = (static_cast<FileItem *>(item))->fullName();
 		if (!ignoreCurrentChanged && fn != st->fileName()) {
 			st->setFileName(fn);
 			st->setSelectItem(true);
@@ -262,7 +262,7 @@ void TreeView::updateTree() {
 				// could be a different subdirectory with the
 				// same name that appears before in tree view
 				// to be sure we need to check the names
-				SCRef fn = ((FileItem*)*item)->fullName();
+				SCRef fn = static_cast<FileItem *>(*item)->fullName();
 				if (st->fileName().startsWith(fn)) {
 
 					if (dynamic_cast<DirItem*>(*item)) {


### PR DESCRIPTION
They do not affect the code, but give lots of diagnostic messages when compiled with -W -Wall -Wextra.  The changes remove them so that other messages warning of potential problems will not be lost among the noise.

The wanings eliminated are:
"declaration shadows a member"
"use of old-style cast"
"can be marked override"
"declaration shadows a parameter"
"declaration shadows a previous local"
"implictly-declared (constructor) is deprecated"
