### PR TITLE
Show newly added files in "working directory changes"

### DIFF
--- a/src/filelist.cpp
+++ b/src/filelist.cpp
@@ -176,9 +176,6 @@ void FileList::insertFiles(const RevFile* files) {
 	setUpdatesEnabled(false);
 	for (int i = 0; i < files->count(); ++i) {
 
-		if (files->statusCmp(i, RevFile::UNKNOWN))
-			continue;
-
 		const bool useDark = QPalette().color(QPalette::Window).value() > QPalette().color(QPalette::WindowText).value();
 
 		QColor clr = palette().color(QPalette::WindowText);
@@ -189,7 +186,7 @@ void FileList::insertFiles(const RevFile* files) {
 		}
 		QString extSt(files->extendedStatus(i));
 		if (extSt.isEmpty()) {
-			if (files->statusCmp(i, RevFile::NEW))
+			if (files->statusCmp(i, RevFile::NEW) || files->statusCmp(i, RevFile::UNKNOWN))
 				clr = useDark ? Qt::darkGreen
 				              : Qt::green;
 			else if (files->statusCmp(i, RevFile::DELETED))


### PR DESCRIPTION
Files which are newly to a repository (but which are not yet staged) do not appear in the lower right pane in QGit.

This patch now causes them to appear there in green (consistent with how new files are shown in the commit dialog)

![show-new-files](https://user-images.githubusercontent.com/10424266/218881189-6642b4db-5b4f-4be0-9eda-5f78b15685e2.png)
