### PR TITLE
FIX #135 Commit list is not readable with dark colors schema

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -163,8 +163,6 @@ namespace QGit {
 	extern const QColor DARK_GREEN;
 
 	// initialized at startup according to system wide settings
-	extern QColor  ODD_LINE_COL;
-	extern QColor  EVEN_LINE_COL;
 	extern QFont   STD_FONT;
 	extern QFont   TYPE_WRITER_FONT;
 	extern QString GIT_DIR;

--- a/src/listview.cpp
+++ b/src/listview.cpp
@@ -93,11 +93,6 @@ int ListView::row(SCRef sha) const {
 
 void ListView::setupGeometry() {
 
-	QPalette pl = palette();
-	pl.setColor(QPalette::Base, ODD_LINE_COL);
-	pl.setColor(QPalette::AlternateBase, EVEN_LINE_COL);
-	setPalette(pl); // does not seem to inherit application paletteAnnotate
-
 	QHeaderView* hv = header();
 	hv->setStretchLastSection(true);
 	hv->setSectionResizeMode(LOG_COL, QHeaderView::Interactive);

--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -65,10 +65,6 @@ MainImpl::MainImpl(SCRef cd, QWidget* p) : QMainWindow(p) {
 	connect(lineEditSHA, SIGNAL(returnPressed()), this, SLOT(lineEditSHA_returnPressed()));
 	connect(lineEditFilter, SIGNAL(returnPressed()), this, SLOT(lineEditFilter_returnPressed()));
 
-	// create light and dark colors for alternate background
-	ODD_LINE_COL = palette().color(QPalette::Base);
-	EVEN_LINE_COL = ODD_LINE_COL.darker(103);
-
 	// our interface to git world
 	git = new Git(this);
 	setupShortcuts();

--- a/src/namespace_def.cpp
+++ b/src/namespace_def.cpp
@@ -136,8 +136,6 @@ const QColor QGit::PURPLE       = QColor(221, 221, 255);
 const QColor QGit::DARK_GREEN   = QColor(0, 205, 0);
 
 // initialized at startup according to system wide settings
-QColor QGit::ODD_LINE_COL;
-QColor QGit::EVEN_LINE_COL;
 QString QGit::GIT_DIR;
 
 /*


### PR DESCRIPTION
Saving Text color (usually black) to use as text color in the commit list.