### PR TITLE
Pass --simplify-merges to git log to counteract the change in git 2.36 that disables history simplification

### DIFF
--- a/src/git.cpp
+++ b/src/git.cpp
@@ -2191,7 +2191,7 @@ bool Git::startRevList(SCList args, FileHistory* fh) {
            then, with this option, file history is truncated to
            the file deletion revision.
         */
-                initCmd << QString("-r -m -p --full-index").split(' ');
+                initCmd << QString("-r -m -p --full-index --simplify-merges").split(' ');
         } else
                 {} // initCmd << QString("--early-output"); currently disabled
 


### PR DESCRIPTION
when doing separate and remerge style merge diffs

Fixes #129.