### PR TITLE
Refactor repository startup directory

### DIFF
--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -154,17 +154,15 @@ MainImpl::MainImpl(SCRef cd, QWidget* p) : QMainWindow(p) {
 	connect(treeView, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)),
 	        this, SLOT(treeView_doubleClicked(QTreeWidgetItem*, int)));
 
-	// use most recent repo as startup dir if it exists and user opted to do so
-	QStringList recents(settings.value(REC_REP_KEY).toStringList());
-	QDir checkRepo;
-	if (	recents.size() >= 1
-		 && testFlag(REOPEN_REPO_F, FLAGS_KEY)
-		 && checkRepo.exists(recents.at(0)))
-	{
-		startUpDir = recents.at(0);
-	}
-	else {
-		startUpDir = (cd.isEmpty() ? QDir::current().absolutePath() : cd);
+	// If enabled in settings, open last opened repository.
+	if(testFlag(REOPEN_REPO_F, FLAGS_KEY)) {
+		const QStringList recents(settings.value(REC_REP_KEY).toStringList());
+		if(!recents.empty() ) {
+			const QDir checkRepo(recents.at(0));
+			if(checkRepo.exists()) {
+				startUpDir = recents.at(0);
+			}
+		}
 	}
 
 	// handle --view-file=* or --view-file * argument


### PR DESCRIPTION
Hi

I do hope this project is still active :). The settings which allows to open the last used repository automatically doesn't work properly. 
Not sure about the use-case of this line:  `startUpDir = (cd.isEmpty() ? QDir::current().absolutePath() : cd);`
At the end of the day, the else part is something that we do not want, right? If I do disable the auto open last repo, then I do not want qgit to do anything. Not even to default to some behavior.

Any thoughts?

