### PR TITLE
appdata: Re-add default tag to screenshot & CI: Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-name: Build (Linux, Ubuntu 20.04 LTS)
+name: Build (Linux, Ubuntu 22.04 LTS)
 
 on:
 - pull_request
@@ -22,8 +22,8 @@ on:
 
 jobs:
   build:
-    name: Build (Linux, Ubuntu 20.04 LTS)
-    runs-on: ubuntu-20.04
+    name: Build (Linux, Ubuntu 22.04 LTS)
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Install build dependencies'
         run: |-
@@ -32,7 +32,6 @@ jobs:
           sudo apt-get install --yes --no-install-recommends \
             build-essential \
             cmake \
-            qt5-default \
             qtbase5-dev
 
       - name: 'Checkout Git branch'

--- a/qgit.appdata.xml
+++ b/qgit.appdata.xml
@@ -18,7 +18,7 @@
     <name>Cristian Tibirna</name>
   </developer>
   <screenshots>
-    <screenshot>
+    <screenshot type="default">
       <caption>Show repository log</caption>
       <image>https://raw.githubusercontent.com/tibirna/qgit/refs/heads/master/screenshots/qgit_main_view.png</image>
     </screenshot>


### PR DESCRIPTION
Commit 1153238 incorrectly removed the 'type="default"' tag for the default screenshot. Add it back.

Fixes: 1153238 appdata: Add screenshots

---

github/workflows/build: Use Ubuntu 22.04