### PR TITLE
Make external diff command work again (fixes #163)

### DIFF
--- a/src/mainimpl.cpp
+++ b/src/mainimpl.cpp
@@ -291,10 +291,8 @@ void MainImpl::ActExternalDiff_activated() {
 	}
 }
 
-const QRegularExpression MainImpl::emptySha("0*");
-
 QString MainImpl::copyFileToDiffIfNeeded(QStringList* filenames, QString sha) {
-	if (emptySha.match(sha).hasMatch())
+	if (sha == QGit::ZERO_SHA)
 	{
 		return QString(curDir + "/" + rv->st.fileName());
 	}

--- a/src/mainimpl.h
+++ b/src/mainimpl.h
@@ -187,7 +187,6 @@ private:
 	QString textToFind;
 	QRegularExpression shortLogRE;
 	QRegularExpression longLogRE;
-	static const QRegularExpression emptySha;
 	QMap<QString, QVariant> revision_variables; // variables used in generic input dialogs
 	bool setRepositoryBusy;
 


### PR DESCRIPTION
.. by fixing SHA1 inspection in method `copyFileToDiffIfNeeded` where any SHA1 matched regex pattern "0*".

That led the external diff feature to always compare the working directory state of a file against itself rather than comparing the version from a given commit against the version from the commit' parent.

Regression from commit 1cb9acfa385e81cb9249e444603d7eff5be64c92

---

Fixes #163

@elBoberido @tibirna does this fix the issue for you?
